### PR TITLE
Incorporated all model code diffs support & corrected code diffs format. Made it similar to SpecStory format.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,12 +17,12 @@ function activate(context) {
     // Register the main commands
     const disposable = vscode.commands.registerCommand('trace-extractor.selectChat', async () => {
         console.log('trace-extractor.selectChat command executed');
-        await showConversationSelector();
+        await showConversationSelector(context);
     });
     
     const disposableJSON = vscode.commands.registerCommand('trace-extractor.selectChatJSON', async () => {
         console.log('trace-extractor.selectChatJSON command executed');
-        await showConversationSelectorJSON();
+        await showConversationSelectorJSON(context);
     });
     
     context.subscriptions.push(disposable, disposableJSON);

--- a/src/chat-selector.js
+++ b/src/chat-selector.js
@@ -4,9 +4,9 @@ const { reconstructConversation, getConversationSummary } = require('./conversat
 /**
  * Get recent conversations from Cursor data
  */
-async function getRecentConversations(limit = 10) {
+async function getRecentConversations(limit = 10, extensionContext = null) {
     console.log('Extracting Cursor data...');
-    const extractedData = await extractCursorDiskKV();
+    const extractedData = await extractCursorDiskKV(null, extensionContext);
     
     if (!extractedData.composers || Object.keys(extractedData.composers).length === 0) {
         console.log('No conversations found');

--- a/src/conversation-parser.js
+++ b/src/conversation-parser.js
@@ -338,12 +338,21 @@ function reconstructConversation(composerId, bubbles, checkpoints, codeDiffs, co
         }
     }
     
+    // Extract unique request IDs from usageUuid fields
+    const requestIds = new Set();
+    for (const bubble of sortedBubbles) {
+        if (bubble.usageUuid) {
+            requestIds.add(bubble.usageUuid);
+        }
+    }
+    
     return {
         composer_id: composerId,
         composer_data: composerData,
         messages: messages,
         code_diffs: composerCodeDiffs,
-        checkpoints: composerCheckpoints
+        checkpoints: composerCheckpoints,
+        request_ids: Array.from(requestIds)
     };
 }
 

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -250,14 +250,23 @@ function parseMessageContent(content) {
         parsed.thinking_blocks.push(thinkingMatch[1].trim());
     }
     
-    // Extract code blocks
-    const codePattern = /```(\w+)?\n([\s\S]*?)\n```/g;
+    // Extract code blocks - improved pattern to handle various formats
+    const codePattern = /```(\w+)?([^\n]*)?\n?([\s\S]*?)```/g;
     let codeMatch;
     
     while ((codeMatch = codePattern.exec(content)) !== null) {
+        // Handle both "```lang\ncode```" and "```code```" formats
+        let language = codeMatch[1] || 'text';
+        let code = codeMatch[3] || codeMatch[2] || '';
+        
+        // If no language specified but first part looks like code, use it
+        if (!codeMatch[1] && codeMatch[2] && !codeMatch[2].includes('\n')) {
+            code = codeMatch[2];
+        }
+        
         parsed.code_blocks.push({
-            language: codeMatch[1] || 'text',
-            code: codeMatch[2].trim()
+            language: language,
+            code: code.trim()
         });
     }
     

--- a/src/markdown-generator.js
+++ b/src/markdown-generator.js
@@ -12,8 +12,8 @@ function formatCodeDiff(oldString, newString) {
     const oldLines = oldString.split('\n');
     const newLines = newString.split('\n');
     
-    // Create a clean diff block
-    let diffBlock = '```diff\n';
+    // Create a clean diff block with separators
+    let diffBlock = '---\n```diff\n';
     
     // For simple single-line changes
     if (oldLines.length === 1 && newLines.length === 1) {
@@ -33,7 +33,7 @@ function formatCodeDiff(oldString, newString) {
         }
     }
     
-    diffBlock += '```';
+    diffBlock += '```\n---';
     return diffBlock;
 }
 
@@ -185,8 +185,8 @@ function formatThinkingBlocks(thinkingBlocks) {
     
     for (const thinking of thinkingBlocks) {
         if (thinking && thinking.trim()) {
-            // Show all thinking content in collapsible details
-            formattedThinking += `<details>\n<summary>🤔 Thinking</summary>\n\n${thinking.trim()}\n\n</details>\n\n`;
+            // Show all thinking content in collapsible details wrapped in think tags
+            formattedThinking += `<think>\n<details>\n<summary>🤔 Thinking</summary>\n\n${thinking.trim()}\n\n</details>\n</think>\n\n`;
         }
     }
     
@@ -282,7 +282,13 @@ function generateMarkdownConversation(conversation) {
     
     // Add conversation metadata
     if (conversation.composer_data?.name) {
-        markdown += `**Conversation ID:** \`${conversation.composer_id.substring(0, 8)}\`  \n`;
+        markdown += `**Conversation ID:** \`${conversation.composer_id}\`  \n`;
+    }
+    
+    // Add request ID (show only the most recent one, which is what's visible in Cursor UI)
+    if (conversation.request_ids && conversation.request_ids.length > 0) {
+        const mostRecentRequestId = conversation.request_ids[conversation.request_ids.length - 1];
+        markdown += `**Request ID:** \`${mostRecentRequestId}\`  \n`;
     }
     
     markdown += `\n---\n\n`;
@@ -378,7 +384,7 @@ function generateConversationFilename(conversation) {
         .substring(0, 50)
         .toLowerCase();
     
-    return `${safeTitle}_${conversation.composer_id.substring(0, 8)}.md`;
+    return `${safeTitle}_${conversation.composer_id}.md`;
 }
 
 module.exports = {

--- a/src/vscode-commands.js
+++ b/src/vscode-commands.js
@@ -14,7 +14,7 @@ const {
 /**
  * Show conversation selection UI in VSCode
  */
-async function showConversationSelector() {
+async function showConversationSelector(extensionContext = null) {
     try {
         // Show progress
         const result = await vscode.window.withProgress({
@@ -32,7 +32,7 @@ async function showConversationSelector() {
             // Get recent conversations
             let conversations;
             try {
-                conversations = await getRecentConversations(10);
+                conversations = await getRecentConversations(10, extensionContext);
             } catch (error) {
                 vscode.window.showErrorMessage(`Failed to load conversations: ${error.message}. Make sure Cursor is installed and you have used it recently.`);
                 return null;
@@ -120,7 +120,7 @@ async function showConversationSelector() {
 /**
  * Show conversation selection UI in VSCode for JSON export
  */
-async function showConversationSelectorJSON() {
+async function showConversationSelectorJSON(extensionContext = null) {
     try {
         // Show progress
         const result = await vscode.window.withProgress({
@@ -138,7 +138,7 @@ async function showConversationSelectorJSON() {
             // Get recent conversations
             let conversations;
             try {
-                conversations = await getRecentConversations(10);
+                conversations = await getRecentConversations(10, extensionContext);
             } catch (error) {
                 vscode.window.showErrorMessage(`Failed to load conversations: ${error.message}. Make sure Cursor is installed and you have used it recently.`);
                 return null;

--- a/tests/compare-models.js
+++ b/tests/compare-models.js
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+
+const { extractCursorDiskKV } = require('../src/extractor');
+
+async function compareModels() {
+    const data = await extractCursorDiskKV();
+    
+    console.log('🔍 ANALYZING CONVERSATION MODEL DIFFERENCES\n');
+    
+    // Find the conversation we just analyzed (183bead9)
+    const targetConv = '183bead9';
+    let targetData = null;
+    
+    for (const [composerId, composer] of Object.entries(data.composers)) {
+        if (composerId.startsWith(targetConv)) {
+            targetData = { composerId, composer };
+            break;
+        }
+    }
+    
+    if (!targetData) {
+        console.log('Target conversation not found');
+        return;
+    }
+    
+    console.log('TARGET CONVERSATION (183bead9):');
+    console.log('Composer data keys:', Object.keys(targetData.composer));
+    console.log('Model info:', {
+        model: targetData.composer.model,
+        modelName: targetData.composer.modelName,
+        provider: targetData.composer.provider
+    });
+    
+    // Analyze tool data structure differences
+    const targetBubbles = data.bubbles[targetData.composerId] || {};
+    let targetToolStructure = null;
+    
+    for (const [bubbleId, bubble] of Object.entries(targetBubbles)) {
+        if (bubble.toolFormerData && bubble.toolFormerData.name === 'edit_file') {
+            targetToolStructure = {
+                keys: Object.keys(bubble.toolFormerData),
+                hasResult: !!bubble.toolFormerData.result,
+                hasRawArgs: !!bubble.toolFormerData.rawArgs,
+                resultStructure: null
+            };
+            
+            if (bubble.toolFormerData.result) {
+                try {
+                    const result = JSON.parse(bubble.toolFormerData.result);
+                    targetToolStructure.resultStructure = Object.keys(result);
+                    targetToolStructure.hasDiff = !!result.diff;
+                    targetToolStructure.hasChunks = !!(result.diff && result.diff.chunks);
+                } catch (e) {
+                    targetToolStructure.resultParseError = e.message;
+                }
+            }
+            break;
+        }
+    }
+    
+    console.log('\nTARGET TOOL STRUCTURE:');
+    console.log(JSON.stringify(targetToolStructure, null, 2));
+    
+    // Compare with other conversations to find different models
+    console.log('\n=== COMPARING WITH OTHER MODELS ===\n');
+    
+    const modelComparison = new Map();
+    let comparedCount = 0;
+    
+    for (const [composerId, composer] of Object.entries(data.composers)) {
+        if (comparedCount >= 15) break; // Limit comparison
+        
+        const modelKey = `${composer.model || 'unknown'}-${composer.provider || 'unknown'}`;
+        
+        if (!modelComparison.has(modelKey)) {
+            modelComparison.set(modelKey, {
+                model: composer.model,
+                provider: composer.provider,
+                modelName: composer.modelName,
+                examples: [],
+                toolStructures: []
+            });
+        }
+        
+        const modelData = modelComparison.get(modelKey);
+        if (modelData.examples.length < 2) {
+            modelData.examples.push(composerId.substring(0, 8));
+            
+            // Check tool structure for this model
+            const bubbles = data.bubbles[composerId] || {};
+            for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+                if (bubble.toolFormerData && modelData.toolStructures.length < 1) {
+                    const toolStructure = {
+                        toolName: bubble.toolFormerData.name || bubble.toolFormerData.tool,
+                        keys: Object.keys(bubble.toolFormerData),
+                        hasResult: !!bubble.toolFormerData.result,
+                        hasRawArgs: !!bubble.toolFormerData.rawArgs,
+                        hasParams: !!bubble.toolFormerData.params
+                    };
+                    
+                    // Check if it's an edit tool with diff structure
+                    if ((toolStructure.toolName === 'edit_file' || toolStructure.toolName === 'Edit') && bubble.toolFormerData.result) {
+                        try {
+                            const result = JSON.parse(bubble.toolFormerData.result);
+                            toolStructure.resultKeys = Object.keys(result);
+                            toolStructure.hasDiffChunks = !!(result.diff && result.diff.chunks);
+                        } catch (e) {
+                            toolStructure.resultParseError = true;
+                        }
+                    }
+                    
+                    modelData.toolStructures.push(toolStructure);
+                    break;
+                }
+            }
+        }
+        
+        comparedCount++;
+    }
+    
+    // Display comparison
+    for (const [modelKey, modelData] of modelComparison.entries()) {
+        console.log(`MODEL: ${modelKey}`);
+        console.log(`  Name: ${modelData.modelName || 'N/A'}`);
+        console.log(`  Examples: ${modelData.examples.join(', ')}`);
+        console.log(`  Tool structures: ${modelData.toolStructures.length}`);
+        
+        if (modelData.toolStructures.length > 0) {
+            const tool = modelData.toolStructures[0];
+            console.log(`    Tool: ${tool.toolName}`);
+            console.log(`    Keys: ${tool.keys.join(', ')}`);
+            console.log(`    Has result: ${tool.hasResult}`);
+            console.log(`    Has rawArgs: ${tool.hasRawArgs}`);
+            console.log(`    Has params: ${tool.hasParams}`);
+            
+            if (tool.resultKeys) {
+                console.log(`    Result keys: ${tool.resultKeys.join(', ')}`);
+                console.log(`    Has diff chunks: ${tool.hasDiffChunks}`);
+            }
+        }
+        console.log('');
+    }
+    
+    // Specific analysis of different tool data formats
+    console.log('=== DETAILED TOOL FORMAT ANALYSIS ===\n');
+    
+    const toolFormats = new Map();
+    
+    for (const [composerId, bubbles] of Object.entries(data.bubbles)) {
+        for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+            if (bubble.toolFormerData) {
+                const composer = data.composers[composerId];
+                const modelKey = `${composer.model || 'unknown'}-${composer.provider || 'unknown'}`;
+                const toolName = bubble.toolFormerData.name || bubble.toolFormerData.tool || 'unknown';
+                
+                const formatKey = `${modelKey}:${toolName}`;
+                
+                if (!toolFormats.has(formatKey)) {
+                    toolFormats.set(formatKey, {
+                        model: modelKey,
+                        toolName,
+                        count: 0,
+                        sampleStructure: {
+                            keys: Object.keys(bubble.toolFormerData),
+                            hasResult: !!bubble.toolFormerData.result,
+                            hasRawArgs: !!bubble.toolFormerData.rawArgs,
+                            hasParams: !!bubble.toolFormerData.params
+                        }
+                    });
+                }
+                
+                toolFormats.get(formatKey).count++;
+            }
+        }
+    }
+    
+    // Show tool format differences
+    for (const [formatKey, format] of toolFormats.entries()) {
+        if (format.count > 5) { // Only show frequently used formats
+            console.log(`${formatKey} (${format.count} instances):`);
+            console.log(`  Keys: ${format.sampleStructure.keys.join(', ')}`);
+            console.log(`  Has result: ${format.sampleStructure.hasResult}`);
+            console.log(`  Has rawArgs: ${format.sampleStructure.hasRawArgs}`);
+            console.log(`  Has params: ${format.sampleStructure.hasParams}`);
+            console.log('');
+        }
+    }
+}
+
+compareModels().catch(console.error);

--- a/tests/debug-tool-data.js
+++ b/tests/debug-tool-data.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+const { extractCursorDiskKV } = require('../src/extractor');
+const { reconstructConversation } = require('../src/conversation-parser');
+
+async function debugToolData() {
+    const data = await extractCursorDiskKV();
+    const targetId = 'a528de3d-b5a6-454f-bf73-4d829383ba05';
+    
+    for (const [composerId, bubbles] of Object.entries(data.bubbles)) {
+        if (composerId.startsWith('183bead9')) {
+            console.log('CONVERSATION:', composerId);
+            
+            const conversation = reconstructConversation(
+                composerId,
+                data.bubbles,
+                data.checkpoints,
+                data.codeDiffs,
+                data.composers[composerId]
+            );
+            
+            console.log('Messages:', conversation.messages.length);
+            
+            conversation.messages.forEach((message, i) => {
+                console.log(`\nMESSAGE ${i+1} (${message.type}):`);
+                console.log('Tool calls:', message.content.tool_calls.length);
+                
+                message.content.tool_calls.forEach((toolCall, j) => {
+                    console.log(`\n  TOOL CALL ${j+1}:`);
+                    console.log('  Tool name:', toolCall.tool_name);
+                    console.log('  Parameters keys:', Object.keys(toolCall.parameters));
+                    
+                    if (toolCall.tool_name === 'Edit' || toolCall.tool_name === 'search_replace') {
+                        console.log('  OLD STRING PRESENT:', !!toolCall.parameters.old_string);
+                        console.log('  NEW STRING PRESENT:', !!toolCall.parameters.new_string);
+                        
+                        if (toolCall.parameters.old_string) {
+                            console.log('  Old string length:', toolCall.parameters.old_string.length);
+                            console.log('  Old string preview:', toolCall.parameters.old_string.substring(0, 100) + '...');
+                        }
+                        if (toolCall.parameters.new_string) {
+                            console.log('  New string length:', toolCall.parameters.new_string.length);
+                            console.log('  New string preview:', toolCall.parameters.new_string.substring(0, 100) + '...');
+                        }
+                    }
+                    
+                    // Check if this tool call contains the target ID
+                    const toolStr = JSON.stringify(toolCall);
+                    if (toolStr.includes(targetId)) {
+                        console.log('  *** CONTAINS TARGET ID ***');
+                        console.log('  Raw content preview:', toolCall.raw_content ? toolCall.raw_content.substring(0, 200) + '...' : 'No raw content');
+                    }
+                });
+            });
+            
+            // Also check raw bubbles for tool data that might not be parsed correctly
+            console.log('\n=== RAW BUBBLE ANALYSIS ===');
+            for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+                const bubbleStr = JSON.stringify(bubble);
+                if (bubbleStr.includes(targetId)) {
+                    console.log(`\nBUBBLE: ${bubbleId}`);
+                    
+                    if (bubble.toolFormerData) {
+                        console.log('  Raw tool data:', JSON.stringify(bubble.toolFormerData, null, 2));
+                        
+                        // Try to parse rawArgs manually
+                        if (bubble.toolFormerData.rawArgs) {
+                            try {
+                                const parsed = JSON.parse(bubble.toolFormerData.rawArgs);
+                                console.log('  Parsed rawArgs keys:', Object.keys(parsed));
+                                
+                                if (parsed.old_string && parsed.new_string) {
+                                    console.log('  *** HAS DIFF DATA IN RAW ARGS ***');
+                                    console.log('  Old string length:', parsed.old_string.length);
+                                    console.log('  New string length:', parsed.new_string.length);
+                                }
+                            } catch (e) {
+                                console.log('  Failed to parse rawArgs:', e.message);
+                                console.log('  Raw args preview:', bubble.toolFormerData.rawArgs.substring(0, 200) + '...');
+                            }
+                        }
+                    }
+                }
+            }
+            
+            break;
+        }
+    }
+}
+
+debugToolData().catch(console.error);

--- a/tests/find-model-differences.js
+++ b/tests/find-model-differences.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+
+const { extractCursorDiskKV } = require('../src/extractor');
+
+async function findDifferentModels() {
+    const data = await extractCursorDiskKV();
+    
+    console.log('🔍 SEARCHING FOR MODEL AND TOOL STRUCTURE DIFFERENCES\n');
+    
+    // Check for conversations with different tool structures
+    console.log('TOOL STRUCTURE VARIATIONS:\n');
+    
+    const toolStructures = new Map();
+    
+    for (const [composerId, bubbles] of Object.entries(data.bubbles)) {
+        for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+            if (bubble.toolFormerData) {
+                const toolName = bubble.toolFormerData.name || bubble.toolFormerData.tool;
+                if (toolName === 'edit_file' || toolName === 'search_replace' || toolName === 'Edit') {
+                    
+                    const structure = {
+                        toolName,
+                        keys: Object.keys(bubble.toolFormerData).sort(),
+                        hasResult: !!bubble.toolFormerData.result,
+                        hasError: !!bubble.toolFormerData.error,
+                        resultType: null
+                    };
+                    
+                    if (bubble.toolFormerData.result) {
+                        try {
+                            const result = JSON.parse(bubble.toolFormerData.result);
+                            structure.resultType = Object.keys(result).sort().join(',');
+                        } catch (e) {
+                            structure.resultType = 'parse_error';
+                        }
+                    }
+                    
+                    const structureKey = JSON.stringify(structure);
+                    if (!toolStructures.has(structureKey)) {
+                        toolStructures.set(structureKey, {
+                            structure,
+                            examples: [],
+                            count: 0
+                        });
+                    }
+                    
+                    const structData = toolStructures.get(structureKey);
+                    structData.count++;
+                    if (structData.examples.length < 3) {
+                        structData.examples.push(composerId.substring(0, 8));
+                    }
+                }
+            }
+        }
+    }
+    
+    for (const [key, data] of toolStructures.entries()) {
+        if (data.count > 5) {
+            console.log(`${data.structure.toolName} (${data.count} instances):`);
+            console.log('  Keys:', data.structure.keys.join(', '));
+            console.log('  Has result:', data.structure.hasResult);
+            console.log('  Has error:', data.structure.hasError);
+            console.log('  Result type:', data.structure.resultType);
+            console.log('  Examples:', data.examples.join(', '));
+            console.log('');
+        }
+    }
+    
+    // Look for specific examples of different formats
+    console.log('=== SPECIFIC EXAMPLES ===\n');
+    
+    // Find one edit_file and one search_replace example
+    let editFileExample = null;
+    let searchReplaceExample = null;
+    
+    for (const [composerId, bubbles] of Object.entries(data.bubbles)) {
+        if (editFileExample && searchReplaceExample) break;
+        
+        for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+            if (bubble.toolFormerData) {
+                const toolName = bubble.toolFormerData.name || bubble.toolFormerData.tool;
+                
+                if (toolName === 'edit_file' && !editFileExample && bubble.toolFormerData.result) {
+                    editFileExample = {
+                        conversationId: composerId.substring(0, 8),
+                        bubbleId,
+                        toolData: bubble.toolFormerData
+                    };
+                }
+                
+                if (toolName === 'search_replace' && !searchReplaceExample) {
+                    searchReplaceExample = {
+                        conversationId: composerId.substring(0, 8),
+                        bubbleId,
+                        toolData: bubble.toolFormerData
+                    };
+                }
+            }
+        }
+    }
+    
+    if (editFileExample) {
+        console.log('EDIT_FILE EXAMPLE (', editFileExample.conversationId, '):');
+        console.log('Tool keys:', Object.keys(editFileExample.toolData));
+        
+        if (editFileExample.toolData.result) {
+            try {
+                const result = JSON.parse(editFileExample.toolData.result);
+                console.log('Result structure:', Object.keys(result));
+                if (result.diff && result.diff.chunks) {
+                    console.log('Diff chunks count:', result.diff.chunks.length);
+                    console.log('First chunk sample keys:', Object.keys(result.diff.chunks[0]));
+                }
+            } catch (e) {
+                console.log('Result parse error:', e.message);
+            }
+        }
+        console.log('');
+    }
+    
+    if (searchReplaceExample) {
+        console.log('SEARCH_REPLACE EXAMPLE (', searchReplaceExample.conversationId, '):');
+        console.log('Tool keys:', Object.keys(searchReplaceExample.toolData));
+        
+        if (searchReplaceExample.toolData.rawArgs) {
+            try {
+                const rawArgs = JSON.parse(searchReplaceExample.toolData.rawArgs);
+                console.log('RawArgs keys:', Object.keys(rawArgs));
+                console.log('Has old_string:', !!rawArgs.old_string);
+                console.log('Has new_string:', !!rawArgs.new_string);
+            } catch (e) {
+                console.log('RawArgs parse error:', e.message);
+            }
+        }
+        console.log('');
+    }
+}
+
+findDifferentModels().catch(console.error);

--- a/tests/find-tool-bubbles.js
+++ b/tests/find-tool-bubbles.js
@@ -1,0 +1,46 @@
+const { extractCursorDiskKV } = require('../src/extractor');
+
+async function findToolBubbles() {
+    const data = await extractCursorDiskKV();
+    const targetId = 'a528de3d-b5a6-454f-bf73-4d829383ba05';
+    
+    for (const [composerId, bubbles] of Object.entries(data.bubbles)) {
+        if (composerId.startsWith('183bead9')) {
+            console.log('CHECKING CONVERSATION:', composerId);
+            
+            for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+                const bubbleStr = JSON.stringify(bubble);
+                const hasTargetId = bubbleStr.includes(targetId);
+                
+                console.log(`\nBubble: ${bubbleId}`);
+                console.log('  Contains target ID:', hasTargetId);
+                console.log('  Has toolFormerData:', !!bubble.toolFormerData);
+                console.log('  Has text:', !!bubble.text);
+                console.log('  Has thinking:', !!bubble.thinking);
+                
+                if (bubble.toolFormerData) {
+                    console.log('  Tool data keys:', Object.keys(bubble.toolFormerData));
+                    console.log('  Tool name/type:', bubble.toolFormerData.name || bubble.toolFormerData.tool);
+                    
+                    if (hasTargetId) {
+                        console.log('  *** TARGET ID FOUND IN THIS TOOL BUBBLE ***');
+                        console.log('  Full tool data:', JSON.stringify(bubble.toolFormerData, null, 2));
+                    }
+                }
+                
+                if (hasTargetId && bubble.text) {
+                    console.log('  *** TARGET ID FOUND IN TEXT ***');
+                    console.log('  Text preview:', bubble.text.substring(0, 200) + '...');
+                }
+                
+                if (hasTargetId && bubble.thinking) {
+                    console.log('  *** TARGET ID FOUND IN THINKING ***');
+                    console.log('  Thinking preview:', bubble.thinking.text ? bubble.thinking.text.substring(0, 200) + '...' : 'No thinking text');
+                }
+            }
+            break;
+        }
+    }
+}
+
+findToolBubbles();

--- a/tests/parsing-test-report.json
+++ b/tests/parsing-test-report.json
@@ -1,0 +1,9654 @@
+{
+  "summary": {
+    "totalConversations": 108,
+    "totalBubbles": 1654,
+    "totalToolCalls": 948,
+    "totalCodeDiffs": 149,
+    "successRate": "100.00%",
+    "failedConversations": 0,
+    "failedBubbles": 0,
+    "failedToolCalls": 275,
+    "failedCodeDiffs": 0,
+    "totalErrors": 275
+  },
+  "failures": {
+    "conversations": [],
+    "bubbles": [],
+    "toolCalls": [
+      {
+        "composerId": "19103896-d859-456a-9562-e659eab685f7",
+        "bubbleId": "851e61d7-66e4-4db2-8ce9-17bd9d05ac0a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "634c669f-11e7-44bd-8491-54817bb8f258",
+        "bubbleId": "75d94a65-1a97-42bc-bac9-8f63bd08cc6c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "161595dd-ec39-484a-9884-09eb7c075771",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "68f1c6f8-e5b2-40a2-b972-9a29bf9f005c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "6a5b23c4-bef6-46cf-a1c8-7860557206c2",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "7d0171dd-051c-4006-9784-850eb8886b60",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "8e4600da-68ab-47ac-b9b0-3a8ce90fcc18",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "d93f5817-393e-4fe7-8b92-66168c02aad2",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "db95e576-b420-40e0-b3c7-760cd96ee3ef",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "f43bb99f-573c-4de7-896a-7918a1fedb8d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "8b18319f-cbf8-441a-a180-96446319c07d",
+        "bubbleId": "fa0abdc9-7c97-42b8-8ec9-ea1220576dc7",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "a39c576c-9036-48a9-b1d6-9d1e773e3aa3",
+        "bubbleId": "3b991410-c563-4fee-84c5-c797474971c5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+        "bubbleId": "43768afd-7cc1-4c93-b532-f6a96a7a61ab",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+        "bubbleId": "ac7753ed-ce73-4f39-8f46-107644d802fd",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "007e2375-167c-4501-aac4-92b6ecc9d425",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "008b6577-90c3-463d-ad5b-8a8de6bcc2a6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "02241395-408b-4c63-827f-80fa524a7621",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "03f6e373-67f2-4c85-8769-52361dc4783c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "051f104c-e13f-4488-8e1c-0f83cb4ea743",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "053c5a07-3e84-4268-b268-b5d83dd3a8a7",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0634fd08-c7dc-47ce-9d76-408a3c70e0bb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0727a54b-b0bf-4575-a00b-ff770ea59856",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0994dcbc-de9c-4812-b5d1-6ad078a59655",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0c64a628-0de7-445f-b953-75a6ddc22907",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0d18a521-e30b-488a-b286-da4a62237c90",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0d8fa13e-b8c9-4bad-9be2-3df578041ddb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "12c5792c-2dd4-4499-8155-d0ae136a4833",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1350be3a-5599-4335-9f10-d26fa824b9ad",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "14463ff4-db62-4afc-8dc1-118113216ec4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1546d489-1575-4b23-b369-c64a3fa4af2b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "16c0b37c-704d-4f58-a957-1e335f648145",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "16e2c5c8-68ef-4b0f-9d14-d263f11d582d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1773d6bd-9b02-4880-8eea-797ffc6babfb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1a52e4f4-583f-4741-b7af-b250a2a544d4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1ca78b17-fca7-4169-aea8-6888344c2c34",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1e89b29e-765d-49ba-bc61-b916cdaf116b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1edda5d9-130d-4581-bd0d-55fe81238e8e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "21c47f47-bd48-4afa-abe4-9a3d4f3b2a9b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2351f607-8c26-4288-a2a1-0c13d9ea8c35",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2440c428-c45b-4cd1-b68c-9d36a114881f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "245c81f5-4300-4862-ba54-7d2f33827382",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "24fc1dd7-3f07-4d42-ba25-034ca6a0bead",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "253b0271-c6a5-4f8d-b8a4-9a8af89c5d25",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "275f0d99-5b43-4191-bef8-01e76ed55cdc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "28d80484-ebf6-4dc0-a636-1eb49951f283",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2a05ec39-e8d5-4071-8faa-4bd974eceef8",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2a82a372-ecbc-4ed8-a049-15cebab632dc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2e550b11-98eb-475b-9236-71816dffc812",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "338f030d-c81e-45a4-aef5-d6ad323c62da",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "33a72f23-113f-4827-89f5-9ab861348950",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "33b19764-85d0-4f4e-975c-4c77ecb9d703",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3691b084-f97b-433a-93b2-de5045fcf395",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3910b914-4bdc-4c0f-9b6d-80f7434f3ba6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "39e27e58-d8aa-4e48-97a3-7d0da70dbe71",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3a075ef0-1acb-409d-9920-021b6b5e110d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3ab7f040-f3cd-4131-96ac-c1ac335c278c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3eb8dd72-3b5b-45e7-9d29-18baa3f82243",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3ebf2af5-a057-4939-8542-b0fb90921c0c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3fd1df29-63d3-4389-be53-ea2cee867674",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4271380b-472b-43f7-9e2d-7b70a4bf6536",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "436d18c5-462e-48bc-860f-62c00a6b9658",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "466c57d2-f41b-427e-abf5-415044a5d351",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "48569353-cf9a-4198-a061-b059f7cea9c8",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "489da48e-bfa6-4f92-a36a-62efdf0b8963",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4a0a48ab-f025-4918-bdb3-2e92b80ed879",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4b0f287d-f8a4-4d8c-a053-09ce8e0eb2c6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4c732785-9a4d-4d5c-ac11-ea7469cfaf20",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "546ada88-4ff4-422a-b757-a0c4a78ff705",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "54cd9218-4137-416a-b052-565ff70546aa",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "55ad8064-dd87-48e2-a633-dd0338bb7ef8",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "57d1ed52-a873-4d49-b727-07e8e4924263",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "582fb216-1b96-44f8-93be-b27443ca4052",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5a70fb98-6a94-4fd8-99a0-948f4d9ee384",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5b3b073b-42b3-4017-9246-b22d4bb8b809",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5bf54026-b695-4ac3-80ce-6afd0513bf63",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5c84c966-bde4-4c04-96d7-71f071e8b894",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5cd1a217-e776-42f2-b91f-10ecc2ec39c6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5cdd5d4a-b59b-461c-897d-1d4005bdd53b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f129307-de38-43be-9e4e-06a7d035e754",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f783da8-51e7-40db-af8e-a084ac0b14e0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f92f9b4-dfc0-4238-ab36-601428aa00d1",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "600581af-cf5e-4f6a-9fff-06125210586e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "604f6349-90d9-4c5c-ab2e-4035fe282607",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "61c4ff4e-855a-433b-954f-212a38ea09a9",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "63047f55-ae5e-433b-88e4-d368266c8e5f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "66617bbe-3b3c-491a-bae0-f2a6f570323e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6677ffb0-99e7-4085-9c54-05f02949a86f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "66e9be23-e420-4f7e-9fba-da06c38b362e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6778be8c-fb29-4fea-8986-650752a9b049",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "69749a70-e618-453a-b027-4eccc1d41a1c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6dea7bca-15e3-4ae8-97ca-6633ae6cf05c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6efd3445-3fc6-4cbc-a69b-69dc8466971a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6fec50b8-043e-495e-9228-3eda42b72018",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "727b8521-5906-4087-8779-95ea4bd67e2f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "73a01a33-9d89-4cfa-be71-fe100dc59564",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "74d41498-e256-4501-81e9-60065c933300",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "762b0718-7d75-4815-b85f-b09083edb78a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "77b8566e-1223-47e2-95bd-fbd93bca30d6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "78049a34-cff1-4bd5-8293-84b6b8b76b45",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "78f7716f-8f1e-4519-b81f-91f7102a3656",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "79c8684a-4e14-4048-821a-de02ad260276",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7b525342-f36d-4e2c-b1a7-97305858982b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7c6e6a6b-159f-4437-af56-f320cc285104",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7cc8e351-89d6-4861-a6bb-e34470f5a9d3",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7cf84a36-d3db-4368-9ce5-137accce8e8c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7eebee2c-6b23-4312-950d-9f297eea06e0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7f6f87d5-c625-4e5b-9d06-731aff58acfa",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "86a9e769-9c8e-4376-bddb-b0c0145f497b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "896d8551-88e5-488b-a548-eb41eb0a4223",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "8dee58ad-fbb5-4ad0-9e0d-dd0fd556dec0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "8f4a0dde-9705-4115-81d0-575324158143",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9005528e-3db6-412c-a741-655278242426",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9170fd68-9b97-4fe0-8f72-05f97efd3920",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9220435e-b8f9-442f-8561-4151da664053",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "95abceb7-d7ae-4c58-8e99-bbe8051f3b9b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "969710f6-8845-4441-b47a-a66d26c5cf13",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "96b66af2-77fa-4e2f-9d06-4a2f4d00c3fb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "96e147ce-5874-4710-bb21-adb68412454f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "97651273-dedb-4f35-9afb-9fe2050905a0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "981c8777-aede-4910-9b04-f6b939c11045",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9a186586-9dd5-46ab-8f3f-89db1a6855ec",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9a90f592-f210-40e8-8105-9204de739ce1",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9aa223b7-e7b8-4a52-9ce5-74e1f91fec42",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9c161f72-6bd9-451c-8de2-9970dc329403",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9d8f3dee-405a-4221-ac8b-61249ce75b62",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9f3fcd61-59ca-4a4e-901f-c41fbc1b2f3b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9f5944bb-a895-4a25-86d4-baa140fd70b0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9fc09f86-4fa3-4ec9-a49d-447db300d242",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a017ca01-a29a-49cf-9716-a0f78bdd901c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a02258e0-a46d-4e21-be26-5b825505b450",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a15e9a2d-a761-4fe5-aac7-4f9df6cb99c0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a1c95df0-e82a-47cc-9e86-078fe231499b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a1cf370c-e9c3-40cb-b458-24c552e6ed49",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a2a6e58d-9dc7-4a93-9ee0-afc0fb1baa97",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a57901d2-4061-4c51-b3b2-2de4e1141234",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a7dc818b-8c88-40a2-83da-4cdfd2429d33",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a8c7449a-9ff9-434d-a278-4ef97ad9436b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "aa7259a3-0c79-4f09-8e0e-d56f8bc68454",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "abf713eb-068a-410b-9500-81ab74d82932",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ae153803-f2b0-4b4b-a118-850baf2000bc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "aedec738-eccc-4388-b675-d75f6d99f586",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "af12ba86-867a-4d89-a84f-0b0063dbd67a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b2df283c-e0e1-45e7-919a-fc8ae4e60b65",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b833acdf-7e19-4128-9ea3-a69935290dc6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b9ce0bfb-f5e1-4334-906c-f78ec31224c6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b9e92c79-89e8-4b7b-abbe-38eac7a74f4e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "bac0accb-ff93-4f99-89b0-91302906f787",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "bde267f9-f164-4660-81d2-9a7bcd70e90a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "be6c963c-9fe8-4dd5-a4fd-a580c9f11c1f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "be9a8299-e829-4660-a12e-a5969de9310c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c1023560-7ef2-4d06-aa93-dbfb538e20e9",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c1b0f537-b7ef-4264-8ee6-182fda90bfa1",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c262d96d-1822-4dea-8b9d-7d33c1d3e8c0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c2b14af0-a0b2-4f51-b74c-e8e5ebe54b4b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c44391e1-0056-45bc-ad43-08c91f85d9e9",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cb0517d6-5926-40fc-b136-6ce28b73a347",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cb05abaa-fc41-4e0a-b16b-640f48f81372",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cc6afe2e-7386-4218-9f52-81a7fdbc9731",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cd07ff92-1f14-4837-9d22-7ff6caaa3811",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cdfa9b15-0b22-4dd3-b1fa-1e1974481774",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ce65d93d-092b-4ce6-9133-a686ce4df31e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ced1fe64-a1d1-48f2-bddb-75ffe7620249",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ced342ac-40ae-4bcf-848a-233688794ed5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d00ba7c1-29bd-449b-8fa0-96c946e91270",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d26c9250-0557-4b0a-a7f4-994c288da48b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d6a67ed2-b879-428f-af04-031e7eb1efda",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d6d1da58-a563-4aad-945d-27181ac1da36",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d7b791c5-97a5-4979-878b-67789d8df20b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d7da5a40-2e90-4b74-ba39-6c02fe375cc8",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d80b4feb-11bf-4fb2-b183-81161c2fdef4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d9fb026f-861a-4cbb-977d-935535f47e25",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "dc8ae2f8-2071-4602-a17f-174111382d60",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "de7d8564-410d-4928-9bd0-c24390ea14a5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e0ae3438-cae6-46fe-84f0-886fcaf31cf1",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e1d4dc51-ec03-4fe2-97b7-b2511748ab00",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e286093f-eea0-4664-b4f2-cb134c833c75",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e300e09c-0219-4be1-a283-3fed993c33f6",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e3d174ed-5c45-47cf-941a-39c0542b1a8e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ec5265f1-65be-49a6-b9bb-4248b01e0e1c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ed1e2698-9f28-474f-bebd-1ab995ea2511",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "efc7e35a-c6e3-4064-a3c2-5220e5494776",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f0fbe70a-6cbe-4af6-8b24-5a25c95c011d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f0ff75dd-240d-49d0-9fb0-dc83d9a5a85d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f31ffe84-6cfa-4203-ba57-882497ed5363",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f4acc30d-ef16-42b4-8b1e-61eaeca6289e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f4efeba8-6545-48b0-972b-fb994314ea53",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f6f8b35c-ccac-4068-b016-eceb3c5d549e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f7b1a0fb-507d-49eb-bb0f-47cec0442a17",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f801c634-2e03-4030-adc4-0e60c222dd9a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f86d49b5-133f-4acd-b2f5-4de834a5b31f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f97fcf8d-ee56-4423-a0ea-a28054cafeb5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "fcb44631-9479-4a0d-a28e-664b697c463b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "feb41c6e-b588-4a11-80df-503339274aa3",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "c11383a8-c83a-4589-b555-33d2f1beeda1",
+        "bubbleId": "62387866-0b7d-48b0-ba2f-aee5a6390b55",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "03baabb6-2a70-43e2-bf34-bfc9574934cb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0578e605-578c-4306-97bc-77abe6f03062",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "08b8f09a-a653-4f78-bf8c-0ea956730294",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "08d32179-8141-4646-8ff0-7d3249f56774",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0ccc9d4e-0121-4e4e-86d5-e73e76ad7de5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0e1e6b77-4e1d-4435-8441-0050a6fb247f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1008498e-a2a0-4dbc-b5fd-edb553addff5",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1516564b-0163-4c49-8aa9-7da1f70bbeb2",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1bb92635-c7e8-464a-ba3f-1489c54ef37b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1c4b16f9-6c87-4a4a-a3f7-1a63654f1d29",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1cf23cfc-65a2-411f-ad8d-449e9aeb3d2a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1eb94697-32c0-470f-8529-b8e2111b8c91",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "221af046-9818-4234-95f7-c7d82ac8922c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "2403ac61-ce42-482a-a607-b7736ec5509c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "2930a7c9-aea5-48ff-add1-4b3e8f71e2d4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "34580d6d-9291-4266-848a-cba6b18ac702",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "367b251a-c0e6-4e2c-b2cc-cec4dde87c54",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "38984f92-662a-4f20-b617-3f04b61085ea",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "3c42d509-9f43-41df-afcc-248d0a1faa83",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "410b98c6-4ac0-4248-ade0-f3e5c531f1b3",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "44577901-692c-4c54-8414-bfd34f224166",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "453a9741-c2f1-4444-9ffa-cca23afe6d30",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "47161e24-92ce-49d5-9c70-330463197865",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "48281258-8736-4eb1-8aaf-6da965380b0a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4f5a68f3-919f-4c77-b65f-c2b6c7fa8780",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4f685bc1-2be4-4028-8e76-b0fe0fb019bc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4fa27308-e02b-4f2c-a9f6-2f75e387b9fe",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "50190342-73dc-4b0a-b232-5bc22df1e9fb",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "5cc498c5-9378-4fdc-9920-f1a2774e691a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "5d8d86eb-45a1-45ed-9ee4-5b6076c1daf0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "64a4a226-8b6c-4ecd-a422-3d334b1b154d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "6c21d8d4-9eac-4352-8930-02f2a7a17eac",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "6cb9fd0d-d390-49a2-abba-1794e20fa43e",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "7972756c-bb35-4a70-963c-f11cf947cc13",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "80809edb-f00a-442a-8c6b-f0877bc1391b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "8137c39d-4e52-40a1-82f7-a2364f893a54",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "814de6d2-7dbe-489f-ad8e-c33f976df38f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "83472a5d-2126-4213-ad78-c26e9e1e71e4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "856a69d3-6a69-4e7d-be76-69a5250e5655",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "85d55225-2d62-44ae-9da6-3b0915964fbf",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "8702cc26-edf6-449a-80d2-34abd3f858f8",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "92d2ab37-3f95-4fb6-b826-ff95d01f9fdc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "958863ac-41f5-4d13-bc08-e044a6426df4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "95d04e5d-1bc9-455f-b76b-1b53453d1e1f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a0b2d50d-2f6a-4db8-ae36-d44667454cf0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a71e422e-13e9-4bcc-9e59-2dfdf8430cd9",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a8d582b1-ff5d-4305-aed5-b79e2d8baf03",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ae60eece-7c5d-4043-a0d7-e0022b33f79d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b0cfba5c-bb49-4c47-aa40-ffcc30dea6c7",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b13a0d3d-93f6-4caa-838c-776d289cd671",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b1c3723a-ac9f-465a-89ee-a82359230ef0",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b2c3fced-2365-4b79-8bdb-e50e6768d022",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "c4509424-cad5-4504-85c9-35fbadcfc904",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "c9da52dc-57ac-4054-80b6-fe00a7d6bc3f",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cb3ad941-73e9-4e7e-a6c5-2b3a90c68d1b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cb8cdd5f-d038-4245-be30-0783c1139c55",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cd0d7d87-0343-4f9e-b6af-b31a815ed397",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d0b6a167-3e33-4215-9386-c8ad5413cebc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d1909109-aaa3-4dcc-869b-13eedba7f69a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d8a46e6f-4fdd-4b95-a5e6-303aee023c16",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d8c8fe7f-ee33-42e7-bc6f-17265ccdd023",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "dd217ba5-21a9-4bcb-884e-6f8c72f4e477",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "de2faf5b-2ca2-4313-b35a-6cebc09e429b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ded870c2-31c2-48db-9555-54d8a47fa53b",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "deed6e07-4242-4488-ba9b-3fe78268801c",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "e1ba71ed-c088-4cd1-a7b6-26da370bff12",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "e7131710-56e1-4f07-b08e-21e3c043d061",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ed295c8f-eb76-4f17-a030-7057451bb465",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ee5d3805-a1dc-452b-854e-5c9b1f09685a",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ee8e751a-32d1-41b0-b099-de120915a5b7",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ef93dddf-b4ee-44f7-86e5-7e7f88179705",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "efd6dd0d-c4d4-4aa7-b70f-8978a5276331",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f1bbce05-db27-4bae-9880-20f4ff81b6b3",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f215c9bc-ef65-4bb0-a405-96b5784a5adc",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f3428f9e-0dd3-4d1c-be0b-cacf9fca0912",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f57ee83f-de9d-4a62-9f28-84b2feec65cf",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f980ea15-2d10-446b-a10f-e5a67ca1cdf4",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fb88e4f3-7bcb-4606-8d61-d477c6cb383d",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fcbd0800-3567-4a6b-b031-8dfd059c0de7",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fd8f5e4d-c0bb-43fe-863b-77aac2118860",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      },
+      {
+        "composerId": "f28b443f-8dd5-409e-aa65-a03db2ed7a59",
+        "bubbleId": "14de2d55-8f95-4a39-b986-5e8039dc6353",
+        "type": "tool_data_parsing",
+        "errors": [
+          {
+            "type": "tool_name_inference_needed",
+            "message": "Tool name missing or unknown, inference required",
+            "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+          }
+        ],
+        "toolData": {
+          "additionalData": {
+            "status": "error"
+          }
+        }
+      }
+    ],
+    "codeDiffs": []
+  },
+  "errors": {
+    "parsing": [
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "19103896-d859-456a-9562-e659eab685f7",
+          "bubbleId": "851e61d7-66e4-4db2-8ce9-17bd9d05ac0a"
+        },
+        "timestamp": "2025-07-19T10:46:25.373Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "634c669f-11e7-44bd-8491-54817bb8f258",
+          "bubbleId": "75d94a65-1a97-42bc-bac9-8f63bd08cc6c"
+        },
+        "timestamp": "2025-07-19T10:46:25.379Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "161595dd-ec39-484a-9884-09eb7c075771"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "68f1c6f8-e5b2-40a2-b972-9a29bf9f005c"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "6a5b23c4-bef6-46cf-a1c8-7860557206c2"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "7d0171dd-051c-4006-9784-850eb8886b60"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "8e4600da-68ab-47ac-b9b0-3a8ce90fcc18"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "d93f5817-393e-4fe7-8b92-66168c02aad2"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "db95e576-b420-40e0-b3c7-760cd96ee3ef"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+          "bubbleId": "f43bb99f-573c-4de7-896a-7918a1fedb8d"
+        },
+        "timestamp": "2025-07-19T10:46:25.381Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "8b18319f-cbf8-441a-a180-96446319c07d",
+          "bubbleId": "fa0abdc9-7c97-42b8-8ec9-ea1220576dc7"
+        },
+        "timestamp": "2025-07-19T10:46:25.382Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "a39c576c-9036-48a9-b1d6-9d1e773e3aa3",
+          "bubbleId": "3b991410-c563-4fee-84c5-c797474971c5"
+        },
+        "timestamp": "2025-07-19T10:46:25.383Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+          "bubbleId": "43768afd-7cc1-4c93-b532-f6a96a7a61ab"
+        },
+        "timestamp": "2025-07-19T10:46:25.385Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+          "bubbleId": "ac7753ed-ce73-4f39-8f46-107644d802fd"
+        },
+        "timestamp": "2025-07-19T10:46:25.385Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "007e2375-167c-4501-aac4-92b6ecc9d425"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "008b6577-90c3-463d-ad5b-8a8de6bcc2a6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "02241395-408b-4c63-827f-80fa524a7621"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "03f6e373-67f2-4c85-8769-52361dc4783c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "051f104c-e13f-4488-8e1c-0f83cb4ea743"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "053c5a07-3e84-4268-b268-b5d83dd3a8a7"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0634fd08-c7dc-47ce-9d76-408a3c70e0bb"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0727a54b-b0bf-4575-a00b-ff770ea59856"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0994dcbc-de9c-4812-b5d1-6ad078a59655"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0c64a628-0de7-445f-b953-75a6ddc22907"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0d18a521-e30b-488a-b286-da4a62237c90"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "0d8fa13e-b8c9-4bad-9be2-3df578041ddb"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "12c5792c-2dd4-4499-8155-d0ae136a4833"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1350be3a-5599-4335-9f10-d26fa824b9ad"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "14463ff4-db62-4afc-8dc1-118113216ec4"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1546d489-1575-4b23-b369-c64a3fa4af2b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "16c0b37c-704d-4f58-a957-1e335f648145"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "16e2c5c8-68ef-4b0f-9d14-d263f11d582d"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1773d6bd-9b02-4880-8eea-797ffc6babfb"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1a52e4f4-583f-4741-b7af-b250a2a544d4"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1ca78b17-fca7-4169-aea8-6888344c2c34"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1e89b29e-765d-49ba-bc61-b916cdaf116b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "1edda5d9-130d-4581-bd0d-55fe81238e8e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "21c47f47-bd48-4afa-abe4-9a3d4f3b2a9b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "2351f607-8c26-4288-a2a1-0c13d9ea8c35"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "2440c428-c45b-4cd1-b68c-9d36a114881f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "245c81f5-4300-4862-ba54-7d2f33827382"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "24fc1dd7-3f07-4d42-ba25-034ca6a0bead"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "253b0271-c6a5-4f8d-b8a4-9a8af89c5d25"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "275f0d99-5b43-4191-bef8-01e76ed55cdc"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "28d80484-ebf6-4dc0-a636-1eb49951f283"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "2a05ec39-e8d5-4071-8faa-4bd974eceef8"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "2a82a372-ecbc-4ed8-a049-15cebab632dc"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "2e550b11-98eb-475b-9236-71816dffc812"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "338f030d-c81e-45a4-aef5-d6ad323c62da"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "33a72f23-113f-4827-89f5-9ab861348950"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "33b19764-85d0-4f4e-975c-4c77ecb9d703"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3691b084-f97b-433a-93b2-de5045fcf395"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3910b914-4bdc-4c0f-9b6d-80f7434f3ba6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "39e27e58-d8aa-4e48-97a3-7d0da70dbe71"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3a075ef0-1acb-409d-9920-021b6b5e110d"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3ab7f040-f3cd-4131-96ac-c1ac335c278c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3eb8dd72-3b5b-45e7-9d29-18baa3f82243"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3ebf2af5-a057-4939-8542-b0fb90921c0c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "3fd1df29-63d3-4389-be53-ea2cee867674"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "4271380b-472b-43f7-9e2d-7b70a4bf6536"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "436d18c5-462e-48bc-860f-62c00a6b9658"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "466c57d2-f41b-427e-abf5-415044a5d351"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "48569353-cf9a-4198-a061-b059f7cea9c8"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "489da48e-bfa6-4f92-a36a-62efdf0b8963"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "4a0a48ab-f025-4918-bdb3-2e92b80ed879"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "4b0f287d-f8a4-4d8c-a053-09ce8e0eb2c6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "4c732785-9a4d-4d5c-ac11-ea7469cfaf20"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "546ada88-4ff4-422a-b757-a0c4a78ff705"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "54cd9218-4137-416a-b052-565ff70546aa"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "55ad8064-dd87-48e2-a633-dd0338bb7ef8"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "57d1ed52-a873-4d49-b727-07e8e4924263"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "582fb216-1b96-44f8-93be-b27443ca4052"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5a70fb98-6a94-4fd8-99a0-948f4d9ee384"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5b3b073b-42b3-4017-9246-b22d4bb8b809"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5bf54026-b695-4ac3-80ce-6afd0513bf63"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5c84c966-bde4-4c04-96d7-71f071e8b894"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5cd1a217-e776-42f2-b91f-10ecc2ec39c6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5cdd5d4a-b59b-461c-897d-1d4005bdd53b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5f129307-de38-43be-9e4e-06a7d035e754"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5f783da8-51e7-40db-af8e-a084ac0b14e0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "5f92f9b4-dfc0-4238-ab36-601428aa00d1"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "600581af-cf5e-4f6a-9fff-06125210586e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "604f6349-90d9-4c5c-ab2e-4035fe282607"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "61c4ff4e-855a-433b-954f-212a38ea09a9"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "63047f55-ae5e-433b-88e4-d368266c8e5f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "66617bbe-3b3c-491a-bae0-f2a6f570323e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "6677ffb0-99e7-4085-9c54-05f02949a86f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "66e9be23-e420-4f7e-9fba-da06c38b362e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "6778be8c-fb29-4fea-8986-650752a9b049"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "69749a70-e618-453a-b027-4eccc1d41a1c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "6dea7bca-15e3-4ae8-97ca-6633ae6cf05c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "6efd3445-3fc6-4cbc-a69b-69dc8466971a"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "6fec50b8-043e-495e-9228-3eda42b72018"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "727b8521-5906-4087-8779-95ea4bd67e2f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "73a01a33-9d89-4cfa-be71-fe100dc59564"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "74d41498-e256-4501-81e9-60065c933300"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "762b0718-7d75-4815-b85f-b09083edb78a"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "77b8566e-1223-47e2-95bd-fbd93bca30d6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "78049a34-cff1-4bd5-8293-84b6b8b76b45"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "78f7716f-8f1e-4519-b81f-91f7102a3656"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "79c8684a-4e14-4048-821a-de02ad260276"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7b525342-f36d-4e2c-b1a7-97305858982b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7c6e6a6b-159f-4437-af56-f320cc285104"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7cc8e351-89d6-4861-a6bb-e34470f5a9d3"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7cf84a36-d3db-4368-9ce5-137accce8e8c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7eebee2c-6b23-4312-950d-9f297eea06e0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "7f6f87d5-c625-4e5b-9d06-731aff58acfa"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "86a9e769-9c8e-4376-bddb-b0c0145f497b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "896d8551-88e5-488b-a548-eb41eb0a4223"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "8dee58ad-fbb5-4ad0-9e0d-dd0fd556dec0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "8f4a0dde-9705-4115-81d0-575324158143"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9005528e-3db6-412c-a741-655278242426"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9170fd68-9b97-4fe0-8f72-05f97efd3920"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9220435e-b8f9-442f-8561-4151da664053"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "95abceb7-d7ae-4c58-8e99-bbe8051f3b9b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "969710f6-8845-4441-b47a-a66d26c5cf13"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "96b66af2-77fa-4e2f-9d06-4a2f4d00c3fb"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "96e147ce-5874-4710-bb21-adb68412454f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "97651273-dedb-4f35-9afb-9fe2050905a0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "981c8777-aede-4910-9b04-f6b939c11045"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9a186586-9dd5-46ab-8f3f-89db1a6855ec"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9a90f592-f210-40e8-8105-9204de739ce1"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9aa223b7-e7b8-4a52-9ce5-74e1f91fec42"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9c161f72-6bd9-451c-8de2-9970dc329403"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9d8f3dee-405a-4221-ac8b-61249ce75b62"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9f3fcd61-59ca-4a4e-901f-c41fbc1b2f3b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9f5944bb-a895-4a25-86d4-baa140fd70b0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "9fc09f86-4fa3-4ec9-a49d-447db300d242"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a017ca01-a29a-49cf-9716-a0f78bdd901c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a02258e0-a46d-4e21-be26-5b825505b450"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a15e9a2d-a761-4fe5-aac7-4f9df6cb99c0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a1c95df0-e82a-47cc-9e86-078fe231499b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a1cf370c-e9c3-40cb-b458-24c552e6ed49"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a2a6e58d-9dc7-4a93-9ee0-afc0fb1baa97"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a57901d2-4061-4c51-b3b2-2de4e1141234"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a7dc818b-8c88-40a2-83da-4cdfd2429d33"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "a8c7449a-9ff9-434d-a278-4ef97ad9436b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "aa7259a3-0c79-4f09-8e0e-d56f8bc68454"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "abf713eb-068a-410b-9500-81ab74d82932"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ae153803-f2b0-4b4b-a118-850baf2000bc"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "aedec738-eccc-4388-b675-d75f6d99f586"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "af12ba86-867a-4d89-a84f-0b0063dbd67a"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "b2df283c-e0e1-45e7-919a-fc8ae4e60b65"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "b833acdf-7e19-4128-9ea3-a69935290dc6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "b9ce0bfb-f5e1-4334-906c-f78ec31224c6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "b9e92c79-89e8-4b7b-abbe-38eac7a74f4e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "bac0accb-ff93-4f99-89b0-91302906f787"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "bde267f9-f164-4660-81d2-9a7bcd70e90a"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "be6c963c-9fe8-4dd5-a4fd-a580c9f11c1f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "be9a8299-e829-4660-a12e-a5969de9310c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "c1023560-7ef2-4d06-aa93-dbfb538e20e9"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "c1b0f537-b7ef-4264-8ee6-182fda90bfa1"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "c262d96d-1822-4dea-8b9d-7d33c1d3e8c0"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "c2b14af0-a0b2-4f51-b74c-e8e5ebe54b4b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "c44391e1-0056-45bc-ad43-08c91f85d9e9"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "cb0517d6-5926-40fc-b136-6ce28b73a347"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "cb05abaa-fc41-4e0a-b16b-640f48f81372"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "cc6afe2e-7386-4218-9f52-81a7fdbc9731"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "cd07ff92-1f14-4837-9d22-7ff6caaa3811"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "cdfa9b15-0b22-4dd3-b1fa-1e1974481774"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ce65d93d-092b-4ce6-9133-a686ce4df31e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ced1fe64-a1d1-48f2-bddb-75ffe7620249"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ced342ac-40ae-4bcf-848a-233688794ed5"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d00ba7c1-29bd-449b-8fa0-96c946e91270"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d26c9250-0557-4b0a-a7f4-994c288da48b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d6a67ed2-b879-428f-af04-031e7eb1efda"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d6d1da58-a563-4aad-945d-27181ac1da36"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d7b791c5-97a5-4979-878b-67789d8df20b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d7da5a40-2e90-4b74-ba39-6c02fe375cc8"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d80b4feb-11bf-4fb2-b183-81161c2fdef4"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "d9fb026f-861a-4cbb-977d-935535f47e25"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "dc8ae2f8-2071-4602-a17f-174111382d60"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "de7d8564-410d-4928-9bd0-c24390ea14a5"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "e0ae3438-cae6-46fe-84f0-886fcaf31cf1"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "e1d4dc51-ec03-4fe2-97b7-b2511748ab00"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "e286093f-eea0-4664-b4f2-cb134c833c75"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "e300e09c-0219-4be1-a283-3fed993c33f6"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "e3d174ed-5c45-47cf-941a-39c0542b1a8e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ec5265f1-65be-49a6-b9bb-4248b01e0e1c"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "ed1e2698-9f28-474f-bebd-1ab995ea2511"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "efc7e35a-c6e3-4064-a3c2-5220e5494776"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f0fbe70a-6cbe-4af6-8b24-5a25c95c011d"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f0ff75dd-240d-49d0-9fb0-dc83d9a5a85d"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f31ffe84-6cfa-4203-ba57-882497ed5363"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f4acc30d-ef16-42b4-8b1e-61eaeca6289e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f4efeba8-6545-48b0-972b-fb994314ea53"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f6f8b35c-ccac-4068-b016-eceb3c5d549e"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f7b1a0fb-507d-49eb-bb0f-47cec0442a17"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f801c634-2e03-4030-adc4-0e60c222dd9a"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f86d49b5-133f-4acd-b2f5-4de834a5b31f"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "f97fcf8d-ee56-4423-a0ea-a28054cafeb5"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "fcb44631-9479-4a0d-a28e-664b697c463b"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+          "bubbleId": "feb41c6e-b588-4a11-80df-503339274aa3"
+        },
+        "timestamp": "2025-07-19T10:46:25.392Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "c11383a8-c83a-4589-b555-33d2f1beeda1",
+          "bubbleId": "62387866-0b7d-48b0-ba2f-aee5a6390b55"
+        },
+        "timestamp": "2025-07-19T10:46:25.393Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "03baabb6-2a70-43e2-bf34-bfc9574934cb"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "0578e605-578c-4306-97bc-77abe6f03062"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "08b8f09a-a653-4f78-bf8c-0ea956730294"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "08d32179-8141-4646-8ff0-7d3249f56774"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "0ccc9d4e-0121-4e4e-86d5-e73e76ad7de5"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "0e1e6b77-4e1d-4435-8441-0050a6fb247f"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1008498e-a2a0-4dbc-b5fd-edb553addff5"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1516564b-0163-4c49-8aa9-7da1f70bbeb2"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1bb92635-c7e8-464a-ba3f-1489c54ef37b"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1c4b16f9-6c87-4a4a-a3f7-1a63654f1d29"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1cf23cfc-65a2-411f-ad8d-449e9aeb3d2a"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "1eb94697-32c0-470f-8529-b8e2111b8c91"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "221af046-9818-4234-95f7-c7d82ac8922c"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "2403ac61-ce42-482a-a607-b7736ec5509c"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "2930a7c9-aea5-48ff-add1-4b3e8f71e2d4"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "34580d6d-9291-4266-848a-cba6b18ac702"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "367b251a-c0e6-4e2c-b2cc-cec4dde87c54"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "38984f92-662a-4f20-b617-3f04b61085ea"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "3c42d509-9f43-41df-afcc-248d0a1faa83"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "410b98c6-4ac0-4248-ade0-f3e5c531f1b3"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "44577901-692c-4c54-8414-bfd34f224166"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "453a9741-c2f1-4444-9ffa-cca23afe6d30"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "47161e24-92ce-49d5-9c70-330463197865"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "48281258-8736-4eb1-8aaf-6da965380b0a"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "4f5a68f3-919f-4c77-b65f-c2b6c7fa8780"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "4f685bc1-2be4-4028-8e76-b0fe0fb019bc"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "4fa27308-e02b-4f2c-a9f6-2f75e387b9fe"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "50190342-73dc-4b0a-b232-5bc22df1e9fb"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "5cc498c5-9378-4fdc-9920-f1a2774e691a"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "5d8d86eb-45a1-45ed-9ee4-5b6076c1daf0"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "64a4a226-8b6c-4ecd-a422-3d334b1b154d"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "6c21d8d4-9eac-4352-8930-02f2a7a17eac"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "6cb9fd0d-d390-49a2-abba-1794e20fa43e"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "7972756c-bb35-4a70-963c-f11cf947cc13"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "80809edb-f00a-442a-8c6b-f0877bc1391b"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "8137c39d-4e52-40a1-82f7-a2364f893a54"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "814de6d2-7dbe-489f-ad8e-c33f976df38f"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "83472a5d-2126-4213-ad78-c26e9e1e71e4"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "856a69d3-6a69-4e7d-be76-69a5250e5655"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "85d55225-2d62-44ae-9da6-3b0915964fbf"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "8702cc26-edf6-449a-80d2-34abd3f858f8"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "92d2ab37-3f95-4fb6-b826-ff95d01f9fdc"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "958863ac-41f5-4d13-bc08-e044a6426df4"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "95d04e5d-1bc9-455f-b76b-1b53453d1e1f"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "a0b2d50d-2f6a-4db8-ae36-d44667454cf0"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "a71e422e-13e9-4bcc-9e59-2dfdf8430cd9"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "a8d582b1-ff5d-4305-aed5-b79e2d8baf03"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ae60eece-7c5d-4043-a0d7-e0022b33f79d"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "b0cfba5c-bb49-4c47-aa40-ffcc30dea6c7"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "b13a0d3d-93f6-4caa-838c-776d289cd671"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "b1c3723a-ac9f-465a-89ee-a82359230ef0"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "b2c3fced-2365-4b79-8bdb-e50e6768d022"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "c4509424-cad5-4504-85c9-35fbadcfc904"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "c9da52dc-57ac-4054-80b6-fe00a7d6bc3f"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "cb3ad941-73e9-4e7e-a6c5-2b3a90c68d1b"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "cb8cdd5f-d038-4245-be30-0783c1139c55"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "cd0d7d87-0343-4f9e-b6af-b31a815ed397"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "d0b6a167-3e33-4215-9386-c8ad5413cebc"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "d1909109-aaa3-4dcc-869b-13eedba7f69a"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "d8a46e6f-4fdd-4b95-a5e6-303aee023c16"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "d8c8fe7f-ee33-42e7-bc6f-17265ccdd023"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "dd217ba5-21a9-4bcb-884e-6f8c72f4e477"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "de2faf5b-2ca2-4313-b35a-6cebc09e429b"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ded870c2-31c2-48db-9555-54d8a47fa53b"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "deed6e07-4242-4488-ba9b-3fe78268801c"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "e1ba71ed-c088-4cd1-a7b6-26da370bff12"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "e7131710-56e1-4f07-b08e-21e3c043d061"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ed295c8f-eb76-4f17-a030-7057451bb465"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ee5d3805-a1dc-452b-854e-5c9b1f09685a"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ee8e751a-32d1-41b0-b099-de120915a5b7"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "ef93dddf-b4ee-44f7-86e5-7e7f88179705"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "efd6dd0d-c4d4-4aa7-b70f-8978a5276331"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "f1bbce05-db27-4bae-9880-20f4ff81b6b3"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "f215c9bc-ef65-4bb0-a405-96b5784a5adc"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "f3428f9e-0dd3-4d1c-be0b-cacf9fca0912"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "f57ee83f-de9d-4a62-9f28-84b2feec65cf"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "f980ea15-2d10-446b-a10f-e5a67ca1cdf4"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "fb88e4f3-7bcb-4606-8d61-d477c6cb383d"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "fcbd0800-3567-4a6b-b031-8dfd059c0de7"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+          "bubbleId": "fd8f5e4d-c0bb-43fe-863b-77aac2118860"
+        },
+        "timestamp": "2025-07-19T10:46:25.401Z"
+      },
+      {
+        "type": "tool_data_parsing",
+        "error": "Tool name missing or unknown, inference required",
+        "context": {
+          "composerId": "f28b443f-8dd5-409e-aa65-a03db2ed7a59",
+          "bubbleId": "14de2d55-8f95-4a39-b986-5e8039dc6353"
+        },
+        "timestamp": "2025-07-19T10:46:25.402Z"
+      }
+    ],
+    "jsonParsing": [],
+    "regex": [],
+    "toolNameInference": [
+      {
+        "composerId": "19103896-d859-456a-9562-e659eab685f7",
+        "bubbleId": "851e61d7-66e4-4db2-8ce9-17bd9d05ac0a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "634c669f-11e7-44bd-8491-54817bb8f258",
+        "bubbleId": "75d94a65-1a97-42bc-bac9-8f63bd08cc6c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "161595dd-ec39-484a-9884-09eb7c075771",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "68f1c6f8-e5b2-40a2-b972-9a29bf9f005c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "6a5b23c4-bef6-46cf-a1c8-7860557206c2",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "7d0171dd-051c-4006-9784-850eb8886b60",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "8e4600da-68ab-47ac-b9b0-3a8ce90fcc18",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "d93f5817-393e-4fe7-8b92-66168c02aad2",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "db95e576-b420-40e0-b3c7-760cd96ee3ef",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "7673302b-7d91-440c-b142-1096aaa6704d",
+        "bubbleId": "f43bb99f-573c-4de7-896a-7918a1fedb8d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "8b18319f-cbf8-441a-a180-96446319c07d",
+        "bubbleId": "fa0abdc9-7c97-42b8-8ec9-ea1220576dc7",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "a39c576c-9036-48a9-b1d6-9d1e773e3aa3",
+        "bubbleId": "3b991410-c563-4fee-84c5-c797474971c5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+        "bubbleId": "43768afd-7cc1-4c93-b532-f6a96a7a61ab",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "b24485e6-28ba-4cd0-a2d3-a00327976eb1",
+        "bubbleId": "ac7753ed-ce73-4f39-8f46-107644d802fd",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "007e2375-167c-4501-aac4-92b6ecc9d425",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "008b6577-90c3-463d-ad5b-8a8de6bcc2a6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "02241395-408b-4c63-827f-80fa524a7621",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "03f6e373-67f2-4c85-8769-52361dc4783c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "051f104c-e13f-4488-8e1c-0f83cb4ea743",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "053c5a07-3e84-4268-b268-b5d83dd3a8a7",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0634fd08-c7dc-47ce-9d76-408a3c70e0bb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0727a54b-b0bf-4575-a00b-ff770ea59856",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0994dcbc-de9c-4812-b5d1-6ad078a59655",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0c64a628-0de7-445f-b953-75a6ddc22907",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0d18a521-e30b-488a-b286-da4a62237c90",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "0d8fa13e-b8c9-4bad-9be2-3df578041ddb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "12c5792c-2dd4-4499-8155-d0ae136a4833",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1350be3a-5599-4335-9f10-d26fa824b9ad",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "14463ff4-db62-4afc-8dc1-118113216ec4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1546d489-1575-4b23-b369-c64a3fa4af2b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "16c0b37c-704d-4f58-a957-1e335f648145",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "16e2c5c8-68ef-4b0f-9d14-d263f11d582d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1773d6bd-9b02-4880-8eea-797ffc6babfb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1a52e4f4-583f-4741-b7af-b250a2a544d4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1ca78b17-fca7-4169-aea8-6888344c2c34",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1e89b29e-765d-49ba-bc61-b916cdaf116b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "1edda5d9-130d-4581-bd0d-55fe81238e8e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "21c47f47-bd48-4afa-abe4-9a3d4f3b2a9b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2351f607-8c26-4288-a2a1-0c13d9ea8c35",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2440c428-c45b-4cd1-b68c-9d36a114881f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "245c81f5-4300-4862-ba54-7d2f33827382",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "24fc1dd7-3f07-4d42-ba25-034ca6a0bead",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "253b0271-c6a5-4f8d-b8a4-9a8af89c5d25",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "275f0d99-5b43-4191-bef8-01e76ed55cdc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "28d80484-ebf6-4dc0-a636-1eb49951f283",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2a05ec39-e8d5-4071-8faa-4bd974eceef8",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2a82a372-ecbc-4ed8-a049-15cebab632dc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "2e550b11-98eb-475b-9236-71816dffc812",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "338f030d-c81e-45a4-aef5-d6ad323c62da",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "33a72f23-113f-4827-89f5-9ab861348950",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "33b19764-85d0-4f4e-975c-4c77ecb9d703",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3691b084-f97b-433a-93b2-de5045fcf395",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3910b914-4bdc-4c0f-9b6d-80f7434f3ba6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "39e27e58-d8aa-4e48-97a3-7d0da70dbe71",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3a075ef0-1acb-409d-9920-021b6b5e110d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3ab7f040-f3cd-4131-96ac-c1ac335c278c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3eb8dd72-3b5b-45e7-9d29-18baa3f82243",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3ebf2af5-a057-4939-8542-b0fb90921c0c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "3fd1df29-63d3-4389-be53-ea2cee867674",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4271380b-472b-43f7-9e2d-7b70a4bf6536",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "436d18c5-462e-48bc-860f-62c00a6b9658",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "466c57d2-f41b-427e-abf5-415044a5d351",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "48569353-cf9a-4198-a061-b059f7cea9c8",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "489da48e-bfa6-4f92-a36a-62efdf0b8963",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4a0a48ab-f025-4918-bdb3-2e92b80ed879",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4b0f287d-f8a4-4d8c-a053-09ce8e0eb2c6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "4c732785-9a4d-4d5c-ac11-ea7469cfaf20",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "546ada88-4ff4-422a-b757-a0c4a78ff705",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "54cd9218-4137-416a-b052-565ff70546aa",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "55ad8064-dd87-48e2-a633-dd0338bb7ef8",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "57d1ed52-a873-4d49-b727-07e8e4924263",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "582fb216-1b96-44f8-93be-b27443ca4052",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5a70fb98-6a94-4fd8-99a0-948f4d9ee384",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5b3b073b-42b3-4017-9246-b22d4bb8b809",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5bf54026-b695-4ac3-80ce-6afd0513bf63",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5c84c966-bde4-4c04-96d7-71f071e8b894",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5cd1a217-e776-42f2-b91f-10ecc2ec39c6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5cdd5d4a-b59b-461c-897d-1d4005bdd53b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f129307-de38-43be-9e4e-06a7d035e754",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f783da8-51e7-40db-af8e-a084ac0b14e0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "5f92f9b4-dfc0-4238-ab36-601428aa00d1",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "600581af-cf5e-4f6a-9fff-06125210586e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "604f6349-90d9-4c5c-ab2e-4035fe282607",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "61c4ff4e-855a-433b-954f-212a38ea09a9",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "63047f55-ae5e-433b-88e4-d368266c8e5f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "66617bbe-3b3c-491a-bae0-f2a6f570323e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6677ffb0-99e7-4085-9c54-05f02949a86f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "66e9be23-e420-4f7e-9fba-da06c38b362e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6778be8c-fb29-4fea-8986-650752a9b049",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "69749a70-e618-453a-b027-4eccc1d41a1c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6dea7bca-15e3-4ae8-97ca-6633ae6cf05c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6efd3445-3fc6-4cbc-a69b-69dc8466971a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "6fec50b8-043e-495e-9228-3eda42b72018",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "727b8521-5906-4087-8779-95ea4bd67e2f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "73a01a33-9d89-4cfa-be71-fe100dc59564",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "74d41498-e256-4501-81e9-60065c933300",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "762b0718-7d75-4815-b85f-b09083edb78a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "77b8566e-1223-47e2-95bd-fbd93bca30d6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "78049a34-cff1-4bd5-8293-84b6b8b76b45",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "78f7716f-8f1e-4519-b81f-91f7102a3656",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "79c8684a-4e14-4048-821a-de02ad260276",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7b525342-f36d-4e2c-b1a7-97305858982b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7c6e6a6b-159f-4437-af56-f320cc285104",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7cc8e351-89d6-4861-a6bb-e34470f5a9d3",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7cf84a36-d3db-4368-9ce5-137accce8e8c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7eebee2c-6b23-4312-950d-9f297eea06e0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "7f6f87d5-c625-4e5b-9d06-731aff58acfa",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "86a9e769-9c8e-4376-bddb-b0c0145f497b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "896d8551-88e5-488b-a548-eb41eb0a4223",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "8dee58ad-fbb5-4ad0-9e0d-dd0fd556dec0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "8f4a0dde-9705-4115-81d0-575324158143",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9005528e-3db6-412c-a741-655278242426",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9170fd68-9b97-4fe0-8f72-05f97efd3920",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9220435e-b8f9-442f-8561-4151da664053",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "95abceb7-d7ae-4c58-8e99-bbe8051f3b9b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "969710f6-8845-4441-b47a-a66d26c5cf13",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "96b66af2-77fa-4e2f-9d06-4a2f4d00c3fb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "96e147ce-5874-4710-bb21-adb68412454f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "97651273-dedb-4f35-9afb-9fe2050905a0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "981c8777-aede-4910-9b04-f6b939c11045",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9a186586-9dd5-46ab-8f3f-89db1a6855ec",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9a90f592-f210-40e8-8105-9204de739ce1",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9aa223b7-e7b8-4a52-9ce5-74e1f91fec42",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9c161f72-6bd9-451c-8de2-9970dc329403",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9d8f3dee-405a-4221-ac8b-61249ce75b62",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9f3fcd61-59ca-4a4e-901f-c41fbc1b2f3b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9f5944bb-a895-4a25-86d4-baa140fd70b0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "9fc09f86-4fa3-4ec9-a49d-447db300d242",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a017ca01-a29a-49cf-9716-a0f78bdd901c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a02258e0-a46d-4e21-be26-5b825505b450",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a15e9a2d-a761-4fe5-aac7-4f9df6cb99c0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a1c95df0-e82a-47cc-9e86-078fe231499b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a1cf370c-e9c3-40cb-b458-24c552e6ed49",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a2a6e58d-9dc7-4a93-9ee0-afc0fb1baa97",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a57901d2-4061-4c51-b3b2-2de4e1141234",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a7dc818b-8c88-40a2-83da-4cdfd2429d33",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "a8c7449a-9ff9-434d-a278-4ef97ad9436b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "aa7259a3-0c79-4f09-8e0e-d56f8bc68454",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "abf713eb-068a-410b-9500-81ab74d82932",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ae153803-f2b0-4b4b-a118-850baf2000bc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "aedec738-eccc-4388-b675-d75f6d99f586",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "af12ba86-867a-4d89-a84f-0b0063dbd67a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b2df283c-e0e1-45e7-919a-fc8ae4e60b65",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b833acdf-7e19-4128-9ea3-a69935290dc6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b9ce0bfb-f5e1-4334-906c-f78ec31224c6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "b9e92c79-89e8-4b7b-abbe-38eac7a74f4e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "bac0accb-ff93-4f99-89b0-91302906f787",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "bde267f9-f164-4660-81d2-9a7bcd70e90a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "be6c963c-9fe8-4dd5-a4fd-a580c9f11c1f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "be9a8299-e829-4660-a12e-a5969de9310c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c1023560-7ef2-4d06-aa93-dbfb538e20e9",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c1b0f537-b7ef-4264-8ee6-182fda90bfa1",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c262d96d-1822-4dea-8b9d-7d33c1d3e8c0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c2b14af0-a0b2-4f51-b74c-e8e5ebe54b4b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "c44391e1-0056-45bc-ad43-08c91f85d9e9",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cb0517d6-5926-40fc-b136-6ce28b73a347",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cb05abaa-fc41-4e0a-b16b-640f48f81372",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cc6afe2e-7386-4218-9f52-81a7fdbc9731",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cd07ff92-1f14-4837-9d22-7ff6caaa3811",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "cdfa9b15-0b22-4dd3-b1fa-1e1974481774",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ce65d93d-092b-4ce6-9133-a686ce4df31e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ced1fe64-a1d1-48f2-bddb-75ffe7620249",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ced342ac-40ae-4bcf-848a-233688794ed5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d00ba7c1-29bd-449b-8fa0-96c946e91270",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d26c9250-0557-4b0a-a7f4-994c288da48b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d6a67ed2-b879-428f-af04-031e7eb1efda",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d6d1da58-a563-4aad-945d-27181ac1da36",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d7b791c5-97a5-4979-878b-67789d8df20b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d7da5a40-2e90-4b74-ba39-6c02fe375cc8",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d80b4feb-11bf-4fb2-b183-81161c2fdef4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "d9fb026f-861a-4cbb-977d-935535f47e25",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "dc8ae2f8-2071-4602-a17f-174111382d60",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "de7d8564-410d-4928-9bd0-c24390ea14a5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e0ae3438-cae6-46fe-84f0-886fcaf31cf1",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e1d4dc51-ec03-4fe2-97b7-b2511748ab00",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e286093f-eea0-4664-b4f2-cb134c833c75",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e300e09c-0219-4be1-a283-3fed993c33f6",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "e3d174ed-5c45-47cf-941a-39c0542b1a8e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ec5265f1-65be-49a6-b9bb-4248b01e0e1c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "ed1e2698-9f28-474f-bebd-1ab995ea2511",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "efc7e35a-c6e3-4064-a3c2-5220e5494776",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f0fbe70a-6cbe-4af6-8b24-5a25c95c011d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f0ff75dd-240d-49d0-9fb0-dc83d9a5a85d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f31ffe84-6cfa-4203-ba57-882497ed5363",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f4acc30d-ef16-42b4-8b1e-61eaeca6289e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f4efeba8-6545-48b0-972b-fb994314ea53",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f6f8b35c-ccac-4068-b016-eceb3c5d549e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f7b1a0fb-507d-49eb-bb0f-47cec0442a17",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f801c634-2e03-4030-adc4-0e60c222dd9a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f86d49b5-133f-4acd-b2f5-4de834a5b31f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "f97fcf8d-ee56-4423-a0ea-a28054cafeb5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "fcb44631-9479-4a0d-a28e-664b697c463b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c0d2837a-d102-48ab-b092-86949863d0b5",
+        "bubbleId": "feb41c6e-b588-4a11-80df-503339274aa3",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "c11383a8-c83a-4589-b555-33d2f1beeda1",
+        "bubbleId": "62387866-0b7d-48b0-ba2f-aee5a6390b55",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "03baabb6-2a70-43e2-bf34-bfc9574934cb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0578e605-578c-4306-97bc-77abe6f03062",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "08b8f09a-a653-4f78-bf8c-0ea956730294",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "08d32179-8141-4646-8ff0-7d3249f56774",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0ccc9d4e-0121-4e4e-86d5-e73e76ad7de5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "0e1e6b77-4e1d-4435-8441-0050a6fb247f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1008498e-a2a0-4dbc-b5fd-edb553addff5",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1516564b-0163-4c49-8aa9-7da1f70bbeb2",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1bb92635-c7e8-464a-ba3f-1489c54ef37b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1c4b16f9-6c87-4a4a-a3f7-1a63654f1d29",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1cf23cfc-65a2-411f-ad8d-449e9aeb3d2a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "1eb94697-32c0-470f-8529-b8e2111b8c91",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "221af046-9818-4234-95f7-c7d82ac8922c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "2403ac61-ce42-482a-a607-b7736ec5509c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "2930a7c9-aea5-48ff-add1-4b3e8f71e2d4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "34580d6d-9291-4266-848a-cba6b18ac702",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "367b251a-c0e6-4e2c-b2cc-cec4dde87c54",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "38984f92-662a-4f20-b617-3f04b61085ea",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "3c42d509-9f43-41df-afcc-248d0a1faa83",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "410b98c6-4ac0-4248-ade0-f3e5c531f1b3",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "44577901-692c-4c54-8414-bfd34f224166",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "453a9741-c2f1-4444-9ffa-cca23afe6d30",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "47161e24-92ce-49d5-9c70-330463197865",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "48281258-8736-4eb1-8aaf-6da965380b0a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4f5a68f3-919f-4c77-b65f-c2b6c7fa8780",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4f685bc1-2be4-4028-8e76-b0fe0fb019bc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "4fa27308-e02b-4f2c-a9f6-2f75e387b9fe",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "50190342-73dc-4b0a-b232-5bc22df1e9fb",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "5cc498c5-9378-4fdc-9920-f1a2774e691a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "5d8d86eb-45a1-45ed-9ee4-5b6076c1daf0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "64a4a226-8b6c-4ecd-a422-3d334b1b154d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "6c21d8d4-9eac-4352-8930-02f2a7a17eac",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "6cb9fd0d-d390-49a2-abba-1794e20fa43e",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "7972756c-bb35-4a70-963c-f11cf947cc13",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "80809edb-f00a-442a-8c6b-f0877bc1391b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "8137c39d-4e52-40a1-82f7-a2364f893a54",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "814de6d2-7dbe-489f-ad8e-c33f976df38f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "83472a5d-2126-4213-ad78-c26e9e1e71e4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "856a69d3-6a69-4e7d-be76-69a5250e5655",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "85d55225-2d62-44ae-9da6-3b0915964fbf",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "8702cc26-edf6-449a-80d2-34abd3f858f8",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "92d2ab37-3f95-4fb6-b826-ff95d01f9fdc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "958863ac-41f5-4d13-bc08-e044a6426df4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "95d04e5d-1bc9-455f-b76b-1b53453d1e1f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a0b2d50d-2f6a-4db8-ae36-d44667454cf0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a71e422e-13e9-4bcc-9e59-2dfdf8430cd9",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "a8d582b1-ff5d-4305-aed5-b79e2d8baf03",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ae60eece-7c5d-4043-a0d7-e0022b33f79d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b0cfba5c-bb49-4c47-aa40-ffcc30dea6c7",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b13a0d3d-93f6-4caa-838c-776d289cd671",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b1c3723a-ac9f-465a-89ee-a82359230ef0",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "b2c3fced-2365-4b79-8bdb-e50e6768d022",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "c4509424-cad5-4504-85c9-35fbadcfc904",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "c9da52dc-57ac-4054-80b6-fe00a7d6bc3f",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cb3ad941-73e9-4e7e-a6c5-2b3a90c68d1b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cb8cdd5f-d038-4245-be30-0783c1139c55",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "cd0d7d87-0343-4f9e-b6af-b31a815ed397",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d0b6a167-3e33-4215-9386-c8ad5413cebc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d1909109-aaa3-4dcc-869b-13eedba7f69a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d8a46e6f-4fdd-4b95-a5e6-303aee023c16",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "d8c8fe7f-ee33-42e7-bc6f-17265ccdd023",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "dd217ba5-21a9-4bcb-884e-6f8c72f4e477",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "de2faf5b-2ca2-4313-b35a-6cebc09e429b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ded870c2-31c2-48db-9555-54d8a47fa53b",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "deed6e07-4242-4488-ba9b-3fe78268801c",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "e1ba71ed-c088-4cd1-a7b6-26da370bff12",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "e7131710-56e1-4f07-b08e-21e3c043d061",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ed295c8f-eb76-4f17-a030-7057451bb465",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ee5d3805-a1dc-452b-854e-5c9b1f09685a",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ee8e751a-32d1-41b0-b099-de120915a5b7",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "ef93dddf-b4ee-44f7-86e5-7e7f88179705",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "efd6dd0d-c4d4-4aa7-b70f-8978a5276331",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f1bbce05-db27-4bae-9880-20f4ff81b6b3",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f215c9bc-ef65-4bb0-a405-96b5784a5adc",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f3428f9e-0dd3-4d1c-be0b-cacf9fca0912",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f57ee83f-de9d-4a62-9f28-84b2feec65cf",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "f980ea15-2d10-446b-a10f-e5a67ca1cdf4",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fb88e4f3-7bcb-4606-8d61-d477c6cb383d",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fcbd0800-3567-4a6b-b031-8dfd059c0de7",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "ec54ff87-efc5-4712-8abe-84ccb965c9fe",
+        "bubbleId": "fd8f5e4d-c0bb-43fe-863b-77aac2118860",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      },
+      {
+        "composerId": "f28b443f-8dd5-409e-aa65-a03db2ed7a59",
+        "bubbleId": "14de2d55-8f95-4a39-b986-5e8039dc6353",
+        "error": {
+          "type": "tool_name_inference_needed",
+          "message": "Tool name missing or unknown, inference required",
+          "toolData": "{\n  \"additionalData\": {\n    \"status\": \"error\"\n  }\n}..."
+        }
+      }
+    ]
+  }
+}

--- a/tests/test-parser.js
+++ b/tests/test-parser.js
@@ -1,0 +1,456 @@
+#!/usr/bin/env node
+
+/**
+ * Comprehensive test to parse all conversations and identify parsing failures
+ * This will help find specific code diffs or bubbles that fail to parse
+ */
+
+const { extractCursorDiskKV, parseMessageContent } = require('../src/extractor');
+const { reconstructConversation } = require('../src/conversation-parser');
+
+class ParsingTestReport {
+    constructor() {
+        this.totalConversations = 0;
+        this.totalBubbles = 0;
+        this.totalToolCalls = 0;
+        this.totalCodeDiffs = 0;
+        this.failedConversations = [];
+        this.failedBubbles = [];
+        this.failedToolCalls = [];
+        this.failedCodeDiffs = [];
+        this.parsingErrors = [];
+        this.jsonParsingErrors = [];
+        this.regexFailures = [];
+        this.toolNameInferenceFailures = [];
+    }
+
+    addError(type, error, context = {}) {
+        this.parsingErrors.push({
+            type,
+            error: error.message || error,
+            stack: error.stack,
+            context,
+            timestamp: new Date().toISOString()
+        });
+    }
+
+    generateReport() {
+        const successRate = this.totalBubbles > 0 ? 
+            ((this.totalBubbles - this.failedBubbles.length) / this.totalBubbles * 100).toFixed(2) : 0;
+
+        return {
+            summary: {
+                totalConversations: this.totalConversations,
+                totalBubbles: this.totalBubbles,
+                totalToolCalls: this.totalToolCalls,
+                totalCodeDiffs: this.totalCodeDiffs,
+                successRate: `${successRate}%`,
+                failedConversations: this.failedConversations.length,
+                failedBubbles: this.failedBubbles.length,
+                failedToolCalls: this.failedToolCalls.length,
+                failedCodeDiffs: this.failedCodeDiffs.length,
+                totalErrors: this.parsingErrors.length
+            },
+            failures: {
+                conversations: this.failedConversations,
+                bubbles: this.failedBubbles,
+                toolCalls: this.failedToolCalls,
+                codeDiffs: this.failedCodeDiffs
+            },
+            errors: {
+                parsing: this.parsingErrors,
+                jsonParsing: this.jsonParsingErrors,
+                regex: this.regexFailures,
+                toolNameInference: this.toolNameInferenceFailures
+            }
+        };
+    }
+}
+
+/**
+ * Test message content parsing with detailed error reporting
+ */
+function testMessageContentParsing(content, bubbleId, composerId) {
+    const errors = [];
+    
+    try {
+        if (!content || typeof content !== 'string') {
+            return { success: true, parsed: null, errors: [] };
+        }
+
+        // Test function calls pattern
+        const functionCallsPattern = /<function_calls>([\s\S]*?)<\/antml:function_calls>/g;
+        let functionCallsMatch;
+        const foundFunctionCalls = [];
+
+        while ((functionCallsMatch = functionCallsPattern.exec(content)) !== null) {
+            foundFunctionCalls.push(functionCallsMatch[1]);
+        }
+
+        // Test antml:function_calls pattern (alternative format)
+        const antmlFunctionCallsPattern = /<function_calls>([\s\S]*?)<\/antml:function_calls>/g;
+        let antmlMatch;
+        const foundAntmlCalls = [];
+
+        while ((antmlMatch = antmlFunctionCallsPattern.exec(content)) !== null) {
+            foundAntmlCalls.push(antmlMatch[1]);
+        }
+
+        // Test invoke patterns
+        const invokePattern = /<invoke name="([^"]+)">([\s\S]*?)<\/antml:invoke>/g;
+        const antmlInvokePattern = /<invoke name="([^"]+)">([\s\S]*?)<\/antml:invoke>/g;
+        
+        // Test parameter patterns
+        const paramPattern = /<parameter name="([^"]+)">([\s\S]*?)<\/antml:parameter>/g;
+        const antmlParamPattern = /<parameter name="([^"]+)">([\s\S]*?)<\/antml:parameter>/g;
+
+        // Try actual parsing
+        const parsed = parseMessageContent(content);
+
+        // Check for potential issues
+        if (content.includes('<function_calls>') && parsed.tool_calls.length === 0) {
+            errors.push({
+                type: 'function_calls_not_parsed',
+                message: 'Content contains <function_calls> but no tool calls were parsed',
+                content: content.substring(0, 500) + '...'
+            });
+        }
+
+        if (content.includes('<function_calls>') && parsed.tool_calls.length === 0) {
+            errors.push({
+                type: 'antml_function_calls_not_parsed',
+                message: 'Content contains <function_calls> but no tool calls were parsed',
+                content: content.substring(0, 500) + '...'
+            });
+        }
+
+        if (content.includes('<thinking>') && parsed.thinking_blocks.length === 0) {
+            errors.push({
+                type: 'thinking_not_parsed',
+                message: 'Content contains <thinking> but no thinking blocks were parsed',
+                content: content.substring(0, 500) + '...'
+            });
+        }
+
+        // Check for actual code blocks (triple backticks followed by newline or language)
+        const hasCodeBlocks = /```(\w+)?\s*\n[\s\S]*?```/g.test(content) || /```[\s\S]{10,}```/g.test(content);
+        if (hasCodeBlocks && parsed.code_blocks.length === 0) {
+            errors.push({
+                type: 'code_blocks_not_parsed',
+                message: 'Content contains ``` but no code blocks were parsed',
+                content: content.substring(0, 500) + '...'
+            });
+        }
+
+        return {
+            success: errors.length === 0,
+            parsed,
+            errors,
+            stats: {
+                functionCallsFound: foundFunctionCalls.length,
+                antmlCallsFound: foundAntmlCalls.length,
+                parsedToolCalls: parsed.tool_calls.length,
+                parsedThinkingBlocks: parsed.thinking_blocks.length,
+                parsedCodeBlocks: parsed.code_blocks.length
+            }
+        };
+
+    } catch (error) {
+        return {
+            success: false,
+            parsed: null,
+            errors: [{
+                type: 'parsing_exception',
+                message: error.message,
+                stack: error.stack
+            }]
+        };
+    }
+}
+
+/**
+ * Test tool data parsing from bubbles
+ */
+function testToolDataParsing(toolData, bubbleId, composerId) {
+    const errors = [];
+    
+    try {
+        if (!toolData) {
+            return { success: true, errors: [] };
+        }
+
+        // Test JSON parsing of rawArgs
+        let parameters = {};
+        if (toolData.rawArgs) {
+            try {
+                parameters = JSON.parse(toolData.rawArgs);
+            } catch (jsonError) {
+                errors.push({
+                    type: 'json_parsing_error',
+                    message: `Failed to parse rawArgs as JSON: ${jsonError.message}`,
+                    rawArgs: toolData.rawArgs.substring(0, 500) + '...',
+                    toolName: toolData.name || toolData.tool || 'unknown'
+                });
+                parameters = { rawArgs: toolData.rawArgs };
+            }
+        }
+
+        // Test tool name detection
+        let toolName = toolData.name || toolData.tool;
+        
+        if (!toolName || toolName === 'unknown_tool') {
+            errors.push({
+                type: 'tool_name_inference_needed',
+                message: 'Tool name missing or unknown, inference required',
+                toolData: JSON.stringify(toolData, null, 2).substring(0, 500) + '...'
+            });
+        }
+
+        return {
+            success: errors.length === 0,
+            errors,
+            toolName,
+            parameters
+        };
+
+    } catch (error) {
+        return {
+            success: false,
+            errors: [{
+                type: 'tool_data_parsing_exception',
+                message: error.message,
+                stack: error.stack
+            }]
+        };
+    }
+}
+
+/**
+ * Main test function
+ */
+async function runParsingTest() {
+    console.log('🔍 Starting comprehensive parsing test...\n');
+    
+    const report = new ParsingTestReport();
+    
+    try {
+        // Extract all data
+        console.log('📊 Extracting Cursor data...');
+        const extractedData = await extractCursorDiskKV();
+        
+        if (!extractedData.composers || Object.keys(extractedData.composers).length === 0) {
+            console.log('❌ No conversations found');
+            return;
+        }
+
+        report.totalConversations = Object.keys(extractedData.composers).length;
+        console.log(`Found ${report.totalConversations} conversations\n`);
+
+        // Test each conversation
+        for (const [composerId, composerData] of Object.entries(extractedData.composers)) {
+            console.log(`\n🔍 Testing conversation ${composerId.substring(0, 8)}...`);
+            
+            try {
+                // Test conversation reconstruction
+                const conversation = reconstructConversation(
+                    composerId,
+                    extractedData.bubbles,
+                    extractedData.checkpoints,
+                    extractedData.codeDiffs,
+                    composerData
+                );
+
+                const composerBubbles = extractedData.bubbles[composerId] || {};
+                const composerCodeDiffs = extractedData.codeDiffs[composerId] || {};
+                
+                report.totalBubbles += Object.keys(composerBubbles).length;
+                report.totalCodeDiffs += Object.keys(composerCodeDiffs).length;
+
+                // Test each bubble
+                for (const [bubbleId, bubble] of Object.entries(composerBubbles)) {
+                    // Test text content parsing
+                    if (bubble.text) {
+                        const textResult = testMessageContentParsing(bubble.text, bubbleId, composerId);
+                        if (!textResult.success) {
+                            report.failedBubbles.push({
+                                composerId,
+                                bubbleId,
+                                type: 'text_parsing',
+                                errors: textResult.errors,
+                                content: bubble.text.substring(0, 200) + '...'
+                            });
+                            textResult.errors.forEach(error => {
+                                report.addError('bubble_text_parsing', error, { composerId, bubbleId });
+                            });
+                        }
+                        
+                        if (textResult.parsed) {
+                            report.totalToolCalls += textResult.parsed.tool_calls.length;
+                        }
+                    }
+
+                    // Test thinking content
+                    if (bubble.thinking && bubble.thinking.text) {
+                        const thinkingResult = testMessageContentParsing(bubble.thinking.text, bubbleId, composerId);
+                        if (!thinkingResult.success) {
+                            report.failedBubbles.push({
+                                composerId,
+                                bubbleId,
+                                type: 'thinking_parsing',
+                                errors: thinkingResult.errors,
+                                content: bubble.thinking.text.substring(0, 200) + '...'
+                            });
+                        }
+                    }
+
+                    // Test tool data
+                    if (bubble.toolFormerData) {
+                        const toolResult = testToolDataParsing(bubble.toolFormerData, bubbleId, composerId);
+                        if (!toolResult.success) {
+                            report.failedToolCalls.push({
+                                composerId,
+                                bubbleId,
+                                type: 'tool_data_parsing',
+                                errors: toolResult.errors,
+                                toolData: bubble.toolFormerData
+                            });
+                            toolResult.errors.forEach(error => {
+                                if (error.type === 'json_parsing_error') {
+                                    report.jsonParsingErrors.push({ composerId, bubbleId, error });
+                                } else if (error.type === 'tool_name_inference_needed') {
+                                    report.toolNameInferenceFailures.push({ composerId, bubbleId, error });
+                                }
+                                report.addError('tool_data_parsing', error, { composerId, bubbleId });
+                            });
+                        }
+                        report.totalToolCalls++;
+                    }
+                }
+
+                // Test code diffs
+                for (const [diffId, codeDiff] of Object.entries(composerCodeDiffs)) {
+                    try {
+                        // Test if code diff contains parseable content
+                        if (codeDiff.content || codeDiff.text || codeDiff.diff) {
+                            const content = codeDiff.content || codeDiff.text || codeDiff.diff;
+                            const diffResult = testMessageContentParsing(content, diffId, composerId);
+                            if (!diffResult.success) {
+                                report.failedCodeDiffs.push({
+                                    composerId,
+                                    diffId,
+                                    errors: diffResult.errors,
+                                    content: content.substring(0, 200) + '...'
+                                });
+                            }
+                        }
+                    } catch (error) {
+                        report.failedCodeDiffs.push({
+                            composerId,
+                            diffId,
+                            error: error.message,
+                            codeDiff
+                        });
+                        report.addError('code_diff_parsing', error, { composerId, diffId });
+                    }
+                }
+
+                console.log(`  ✅ Processed conversation with ${Object.keys(composerBubbles).length} bubbles`);
+
+            } catch (error) {
+                report.failedConversations.push({
+                    composerId,
+                    error: error.message,
+                    stack: error.stack
+                });
+                report.addError('conversation_reconstruction', error, { composerId });
+                console.log(`  ❌ Failed to process conversation: ${error.message}`);
+            }
+        }
+
+    } catch (error) {
+        report.addError('extraction', error);
+        console.error('❌ Fatal error during extraction:', error);
+    }
+
+    // Generate and display report
+    console.log('\n' + '='.repeat(80));
+    console.log('📊 PARSING TEST REPORT');
+    console.log('='.repeat(80));
+
+    const finalReport = report.generateReport();
+    
+    console.log('\n📈 SUMMARY:');
+    console.log(`Total Conversations: ${finalReport.summary.totalConversations}`);
+    console.log(`Total Bubbles: ${finalReport.summary.totalBubbles}`);
+    console.log(`Total Tool Calls: ${finalReport.summary.totalToolCalls}`);
+    console.log(`Total Code Diffs: ${finalReport.summary.totalCodeDiffs}`);
+    console.log(`Success Rate: ${finalReport.summary.successRate}`);
+    console.log(`Failed Conversations: ${finalReport.summary.failedConversations}`);
+    console.log(`Failed Bubbles: ${finalReport.summary.failedBubbles}`);
+    console.log(`Failed Tool Calls: ${finalReport.summary.failedToolCalls}`);
+    console.log(`Failed Code Diffs: ${finalReport.summary.failedCodeDiffs}`);
+    console.log(`Total Errors: ${finalReport.summary.totalErrors}`);
+
+    if (finalReport.failures.bubbles.length > 0) {
+        console.log('\n❌ FAILED BUBBLES:');
+        finalReport.failures.bubbles.slice(0, 10).forEach((failure, index) => {
+            console.log(`\n${index + 1}. Bubble ${failure.bubbleId} in conversation ${failure.composerId.substring(0, 8)}`);
+            console.log(`   Type: ${failure.type}`);
+            console.log(`   Errors: ${failure.errors.length}`);
+            if (failure.errors.length > 0) {
+                console.log(`   First Error: ${failure.errors[0].message || failure.errors[0].type}`);
+            }
+            if (failure.content) {
+                console.log(`   Content Preview: ${failure.content.substring(0, 100)}...`);
+            }
+        });
+        if (finalReport.failures.bubbles.length > 10) {
+            console.log(`\n... and ${finalReport.failures.bubbles.length - 10} more failed bubbles`);
+        }
+    }
+
+    if (finalReport.failures.toolCalls.length > 0) {
+        console.log('\n❌ FAILED TOOL CALLS:');
+        finalReport.failures.toolCalls.slice(0, 5).forEach((failure, index) => {
+            console.log(`\n${index + 1}. Tool call in bubble ${failure.bubbleId} (conversation ${failure.composerId.substring(0, 8)})`);
+            console.log(`   Type: ${failure.type}`);
+            console.log(`   Errors: ${failure.errors.length}`);
+            if (failure.errors.length > 0) {
+                console.log(`   First Error: ${failure.errors[0].message || failure.errors[0].type}`);
+            }
+        });
+        if (finalReport.failures.toolCalls.length > 5) {
+            console.log(`\n... and ${finalReport.failures.toolCalls.length - 5} more failed tool calls`);
+        }
+    }
+
+    if (report.jsonParsingErrors.length > 0) {
+        console.log('\n🔧 JSON PARSING ERRORS:');
+        report.jsonParsingErrors.slice(0, 5).forEach((failure, index) => {
+            console.log(`${index + 1}. ${failure.error.message}`);
+            if (failure.error.rawArgs) {
+                console.log(`   Raw Args: ${failure.error.rawArgs.substring(0, 100)}...`);
+            }
+        });
+    }
+
+    if (report.toolNameInferenceFailures.length > 0) {
+        console.log('\n🔧 TOOL NAME INFERENCE NEEDED:');
+        console.log(`${report.toolNameInferenceFailures.length} tool calls need name inference`);
+    }
+
+    // Save detailed report to file
+    const fs = require('fs');
+    const reportPath = './parsing-test-report.json';
+    fs.writeFileSync(reportPath, JSON.stringify(finalReport, null, 2));
+    console.log(`\n💾 Detailed report saved to: ${reportPath}`);
+
+    console.log('\n✅ Parsing test completed!');
+}
+
+// Run the test
+if (require.main === module) {
+    runParsingTest().catch(console.error);
+}
+
+module.exports = { runParsingTest, testMessageContentParsing, testToolDataParsing };

--- a/tests/test-specific-request.js
+++ b/tests/test-specific-request.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+/**
+ * Test specific request ID to debug missing code diff
+ */
+
+const { extractCursorDiskKV, parseMessageContent } = require('../src/extractor');
+const { reconstructConversation } = require('../src/conversation-parser');
+const { generateMarkdownConversation } = require('../src/markdown-generator');
+
+async function testSpecificRequest() {
+    const targetRequestId = 'a528de3d-b5a6-454f-bf73-4d829383ba05';
+    
+    console.log(`🔍 Testing specific request ID: ${targetRequestId}\n`);
+    
+    try {
+        // Extract all data
+        console.log('📊 Extracting Cursor data...');
+        const extractedData = await extractCursorDiskKV();
+        
+        if (!extractedData.composers || Object.keys(extractedData.composers).length === 0) {
+            console.log('❌ No conversations found');
+            return;
+        }
+
+        console.log(`Found ${Object.keys(extractedData.composers).length} conversations`);
+        
+        // Look for the specific request ID in all data structures
+        console.log('\n🔍 Searching for request ID in all data structures...');
+        
+        let foundInBubbles = false;
+        let foundInCheckpoints = false;
+        let foundInCodeDiffs = false;
+        let foundInComposers = false;
+        let matchingConversations = [];
+        
+        // Search in bubbles
+        for (const [composerId, bubbles] of Object.entries(extractedData.bubbles)) {
+            for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+                const bubbleStr = JSON.stringify(bubble);
+                if (bubbleStr.includes(targetRequestId)) {
+                    foundInBubbles = true;
+                    console.log(`✅ Found in bubble: ${bubbleId} (conversation: ${composerId.substring(0, 8)})`);
+                    
+                    if (!matchingConversations.includes(composerId)) {
+                        matchingConversations.push(composerId);
+                    }
+                    
+                    // Analyze the bubble content
+                    console.log(`   - Bubble type: ${bubble.type}`);
+                    console.log(`   - Has text: ${!!bubble.text}`);
+                    console.log(`   - Has thinking: ${!!bubble.thinking}`);
+                    console.log(`   - Has toolFormerData: ${!!bubble.toolFormerData}`);
+                    
+                    if (bubble.text && bubble.text.includes(targetRequestId)) {
+                        console.log(`   - Found in text content`);
+                        const parsed = parseMessageContent(bubble.text);
+                        console.log(`   - Parsed tool calls: ${parsed.tool_calls.length}`);
+                        console.log(`   - Parsed code blocks: ${parsed.code_blocks.length}`);
+                        
+                        if (parsed.code_blocks.length > 0) {
+                            console.log(`   - Code blocks found:`);
+                            parsed.code_blocks.forEach((block, i) => {
+                                console.log(`     ${i+1}. Language: ${block.language}, Length: ${block.code.length}`);
+                            });
+                        }
+                    }
+                    
+                    if (bubble.toolFormerData) {
+                        console.log(`   - Tool data: ${JSON.stringify(bubble.toolFormerData, null, 2).substring(0, 200)}...`);
+                    }
+                }
+            }
+        }
+        
+        // Search in checkpoints
+        for (const [composerId, checkpoints] of Object.entries(extractedData.checkpoints)) {
+            for (const [checkpointId, checkpoint] of Object.entries(checkpoints)) {
+                const checkpointStr = JSON.stringify(checkpoint);
+                if (checkpointStr.includes(targetRequestId)) {
+                    foundInCheckpoints = true;
+                    console.log(`✅ Found in checkpoint: ${checkpointId} (conversation: ${composerId.substring(0, 8)})`);
+                    
+                    if (!matchingConversations.includes(composerId)) {
+                        matchingConversations.push(composerId);
+                    }
+                }
+            }
+        }
+        
+        // Search in code diffs
+        for (const [composerId, codeDiffs] of Object.entries(extractedData.codeDiffs)) {
+            for (const [diffId, codeDiff] of Object.entries(codeDiffs)) {
+                const diffStr = JSON.stringify(codeDiff);
+                if (diffStr.includes(targetRequestId)) {
+                    foundInCodeDiffs = true;
+                    console.log(`✅ Found in code diff: ${diffId} (conversation: ${composerId.substring(0, 8)})`);
+                    console.log(`   - Code diff structure:`, Object.keys(codeDiff));
+                    console.log(`   - Content preview:`, JSON.stringify(codeDiff, null, 2).substring(0, 500) + '...');
+                    
+                    if (!matchingConversations.includes(composerId)) {
+                        matchingConversations.push(composerId);
+                    }
+                }
+            }
+        }
+        
+        // Search in composers
+        for (const [composerId, composer] of Object.entries(extractedData.composers)) {
+            const composerStr = JSON.stringify(composer);
+            if (composerStr.includes(targetRequestId)) {
+                foundInComposers = true;
+                console.log(`✅ Found in composer: ${composerId.substring(0, 8)}`);
+                
+                if (!matchingConversations.includes(composerId)) {
+                    matchingConversations.push(composerId);
+                }
+            }
+        }
+        
+        // Summary
+        console.log('\n📊 SEARCH RESULTS:');
+        console.log(`Found in bubbles: ${foundInBubbles}`);
+        console.log(`Found in checkpoints: ${foundInCheckpoints}`);
+        console.log(`Found in code diffs: ${foundInCodeDiffs}`);
+        console.log(`Found in composers: ${foundInComposers}`);
+        console.log(`Matching conversations: ${matchingConversations.length}`);
+        
+        if (matchingConversations.length === 0) {
+            console.log('\n❌ Request ID not found in any data structure');
+            
+            // Search for partial matches
+            console.log('\n🔍 Searching for partial matches...');
+            const partialId = targetRequestId.split('-')[0]; // First part
+            
+            for (const [composerId, bubbles] of Object.entries(extractedData.bubbles)) {
+                for (const [bubbleId, bubble] of Object.entries(bubbles)) {
+                    const bubbleStr = JSON.stringify(bubble);
+                    if (bubbleStr.includes(partialId)) {
+                        console.log(`📍 Partial match in bubble: ${bubbleId} (conversation: ${composerId.substring(0, 8)})`);
+                    }
+                }
+            }
+            return;
+        }
+        
+        // Analyze each matching conversation
+        for (const composerId of matchingConversations) {
+            console.log(`\n🔍 Analyzing conversation: ${composerId.substring(0, 8)}`);
+            
+            try {
+                const conversation = reconstructConversation(
+                    composerId,
+                    extractedData.bubbles,
+                    extractedData.checkpoints,
+                    extractedData.codeDiffs,
+                    extractedData.composers[composerId]
+                );
+                
+                console.log(`   - Messages: ${conversation.messages.length}`);
+                console.log(`   - Code diffs: ${Object.keys(conversation.code_diffs).length}`);
+                
+                // Check if request ID appears in any message
+                conversation.messages.forEach((message, index) => {
+                    const messageStr = JSON.stringify(message);
+                    if (messageStr.includes(targetRequestId)) {
+                        console.log(`   - Found in message ${index + 1} (${message.type})`);
+                        
+                        // Check tool calls for code diffs
+                        if (message.content.tool_calls) {
+                            message.content.tool_calls.forEach((toolCall, toolIndex) => {
+                                const toolStr = JSON.stringify(toolCall);
+                                if (toolStr.includes(targetRequestId)) {
+                                    console.log(`     - Found in tool call ${toolIndex + 1}: ${toolCall.tool_name}`);
+                                    
+                                    if (toolCall.tool_name === 'Edit' || toolCall.tool_name === 'search_replace') {
+                                        console.log(`     - This is a code diff tool call!`);
+                                        console.log(`     - Parameters:`, Object.keys(toolCall.parameters));
+                                        
+                                        if (toolCall.parameters.old_string || toolCall.parameters.new_string) {
+                                            console.log(`     - Has old_string: ${!!toolCall.parameters.old_string}`);
+                                            console.log(`     - Has new_string: ${!!toolCall.parameters.new_string}`);
+                                            
+                                            if (toolCall.parameters.old_string) {
+                                                console.log(`     - Old string length: ${toolCall.parameters.old_string.length}`);
+                                            }
+                                            if (toolCall.parameters.new_string) {
+                                                console.log(`     - New string length: ${toolCall.parameters.new_string.length}`);
+                                            }
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                    }
+                });
+                
+                // Generate markdown to see how it appears
+                console.log(`\n📝 Generating markdown for conversation...`);
+                const markdown = generateMarkdownConversation(conversation);
+                
+                // Check if request ID appears in markdown
+                if (markdown.includes(targetRequestId)) {
+                    console.log(`✅ Request ID appears in generated markdown`);
+                    
+                    // Find the specific section
+                    const lines = markdown.split('\n');
+                    lines.forEach((line, index) => {
+                        if (line.includes(targetRequestId)) {
+                            console.log(`   - Line ${index + 1}: ${line.substring(0, 100)}...`);
+                        }
+                    });
+                } else {
+                    console.log(`❌ Request ID does NOT appear in generated markdown`);
+                    console.log(`   - This indicates the code diff parsing/formatting might be failing`);
+                }
+                
+                // Save this conversation's markdown for inspection
+                const fs = require('fs');
+                const filename = `debug-conversation-${composerId.substring(0, 8)}.md`;
+                fs.writeFileSync(filename, markdown);
+                console.log(`   - Saved markdown to: ${filename}`);
+                
+            } catch (error) {
+                console.log(`❌ Error reconstructing conversation: ${error.message}`);
+            }
+        }
+        
+    } catch (error) {
+        console.error('❌ Fatal error:', error);
+    }
+}
+
+// Run the test
+if (require.main === module) {
+    testSpecificRequest().catch(console.error);
+}
+
+module.exports = { testSpecificRequest };

--- a/tests/test-specific-request.js
+++ b/tests/test-specific-request.js
@@ -9,7 +9,7 @@ const { reconstructConversation } = require('../src/conversation-parser');
 const { generateMarkdownConversation } = require('../src/markdown-generator');
 
 async function testSpecificRequest() {
-    const targetRequestId = 'a528de3d-b5a6-454f-bf73-4d829383ba05';
+    const targetRequestId = process.argv[2] || 'bde16f1d-48ae-4787-bfc7-45dba72f5c4e';
     
     console.log(`🔍 Testing specific request ID: ${targetRequestId}\n`);
     


### PR DESCRIPTION
- Claude format used edit_file and Grok uses search_replace. That's why code diff was not showing. I have incorporated both structures and **finally all models are supported** 🚀.

- Added code diff similar to SpecStory as + and -
- Fixed truncation in code diff.

- Also added the support for --user-data-dir (If cursor is started with that flag).
- Added <think> in thinking
- Added separators so that the markdown is clean.